### PR TITLE
feat: add npm format command

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9437,6 +9437,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
     "clean": "rm -rf .cache dist",
     "build": "parcel build -d dist --no-content-hash --no-source-maps manifest.json",
     "clean-build": "npm run clean && npm run build",
-    "test": "jest --collectCoverage"
+    "test": "jest --collectCoverage",
+    "format": "prettier --write src/**/*.ts"
   },
   "author": "",
   "license": "ISC",
@@ -24,6 +25,7 @@
     "jest-webextension-mock": "^3.6.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-web-extension": "^1.6.1",
+    "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "typescript": "^3.9.5"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "build": "parcel build -d dist --no-content-hash --no-source-maps manifest.json",
     "clean-build": "npm run clean && npm run build",
     
-    "format": "prettier --write src/**/*.ts"
+    "format": "prettier --write src/**/*.ts",
 
     "test": "jest --collectCoverage --verbose",
     "integration-test": "jest --collectCoverage --verbose --config __integration__/jest.config.js",


### PR DESCRIPTION
Added a command, `npm run format` to automatically run prettify. This will modify files, so the following workflow is recommended:

1) Build and test your feature
2) Make sure all your changes are committed
3) run `npm run format`
4) The format may have modified files outside of your feature. `git add` **only** files you worked on, and make a new commit like `fix: run formatter`.