### PR TITLE
Create types for API return values

### DIFF
--- a/app/src/common/types/Breakpoint.ts
+++ b/app/src/common/types/Breakpoint.ts
@@ -1,0 +1,43 @@
+/**
+ * Typescript definitions for data returned by the debugger.
+ */
+
+ /** Used to represent breakpoints that have not yet completed. */
+export interface BreakpointMeta {
+    id: string;
+    location: {
+        path: string;
+        line: number;
+    };
+    createTime: string;
+    userEmail: string;
+}
+
+/** Used to represent breakpoints that have completed. */
+export interface Breakpoint extends BreakpointMeta {
+    isFinalState: boolean;
+    stackFrames: Array<any>;
+    variableTable: Array<any>;
+    finalTime: string;
+    labels: any;
+}
+
+/* A single GCP project */
+export interface Project {
+    projectNumber: string;
+    projectId: string;
+    lifecycleState: string;
+    name: string;
+    createTime: string;
+}
+
+/** A single debuggee within a GCP project */
+export interface Debuggee {
+    id: string;
+    project: string;
+    uniquifier: string;
+    description: string;
+    agentVersion: string;
+    sourceContext: Array<any>;
+    labels: any;
+}


### PR DESCRIPTION
**Work Done**
Created typescript definitions for return types from debugger. Some sub-properties aren't defined yet, but can be added in later.