### PR TITLE
Add back buttons to change project and debuggee

### DIFF
--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -8,7 +8,8 @@ import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
 import { PendingBreakpointView, CompletedBreakpointView } from "./BreakpointView";
 
 import Paper from "@material-ui/core/Paper";
-import { AppBar, Toolbar, Typography } from "@material-ui/core";
+import { AppBar, Toolbar, Typography, IconButton } from "@material-ui/core";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 // Jest has trouble with this, so only import in actual builds.
 if(process.env.NODE_ENV !== "test"){
   import("fontsource-roboto");
@@ -60,6 +61,9 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
               // Response.debuggees will be undefined if there are no active debuggees.
               return response.debuggees || [];
             }}
+            backToProjects={() => {
+              this.props.setProject(undefined);
+            }}
           />
         )}
 
@@ -67,6 +71,9 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
           <>
             <AppBar position="static">
               <Toolbar>
+                <IconButton edge="start" color="inherit" onClick={() => this.props.setDebuggee(undefined)}>
+                  <ArrowBackIcon/>
+                </IconButton>
                 <Typography variant="h6">Breakpoints</Typography>
               </Toolbar>
             </AppBar>
@@ -91,7 +98,7 @@ const ChatheadWrapper = styled(Paper)`
   top: 20px;
 
   right: 20px;
-  width: 300px;
+  width: fit-content;
 
   z-index: 1000;
 `;

--- a/app/src/client/chathead/SelectDebuggee.tsx
+++ b/app/src/client/chathead/SelectDebuggee.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { SelectView } from "./GeneralSelectView";
 import { Debuggee } from "../../common/types/debugger";
-import { Toolbar, Typography, AppBar, Card, CardContent, Box } from "@material-ui/core";
-
+import { Toolbar, Typography, AppBar, Card, CardContent, Box, IconButton } from "@material-ui/core";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 interface SelectDebuggeeContainerProps {
   projectId: string;
   debuggeeId?: string;
   loadDebuggees: () => Promise<Debuggee[]>;
   onChange: (debuggeeId) => void;
+  backToProjects: () => void;
 }
 
 interface SelectDebuggeeContainerState {
@@ -45,6 +46,9 @@ export class SelectDebuggeeContainer extends React.Component<
       <>
         <AppBar position="static">
           <Toolbar>
+            <IconButton edge="start" color="inherit" onClick={this.props.backToProjects}>
+              <ArrowBackIcon/>
+            </IconButton>
             <Typography variant="h6">{this.props.projectId}</Typography>
           </Toolbar>
         </AppBar>


### PR DESCRIPTION
**Background**
Currently there's no way to change the selected project and debuggee without a refresh.

**Work Done**
Added back buttons that "reset" these by setting to undefined.

![image](https://user-images.githubusercontent.com/17712692/87448243-8e9d6700-c5c9-11ea-879b-d67e7675c711.png)

![image](https://user-images.githubusercontent.com/17712692/87448297-a674eb00-c5c9-11ea-9c9a-f0f422931ff4.png)

