### PR TITLE
Throw errors from background in the frontend

### DIFF
--- a/app/__tests__/backgroundRequest.ts
+++ b/app/__tests__/backgroundRequest.ts
@@ -13,7 +13,7 @@ import {
   GetAuthStateRequestData,
   BackgroundRequestResponse,
   BackgroundRequestResponseFactory,
-  BackgroundRequestError
+  BackgroundRequestError,
   DeleteBreakpointRequestData,
   EnableRequiredServiceRequestData,
   RequiredServicesEnabledRequestData


### PR DESCRIPTION
**Background**
Currently we don't do much error handling. In general, most errors will be generated in the background script, but must be displayed in the frontend. since these are 'insulated' by chrome message passing, errors aren't automatically bubbled.

**Work Done**
Added logic to more tightly constrain the format of responses from background -> UI. Some changes include an `isError` field that let's the BackgroundRequest class determine if a request generated an error. 

This was done in a way that minimizes the overall code changes needed.
- On the front-end, anything calling `run()` on request handlers continue to get the same data type response as before. Then can individually opt into handling a promise rejection to show an error.
- On the back end, only the `BackgroundRequestHandler.on` method will need to be slightly rewritten to accommodate the new request format.
 - Additionally, based on the previous, `on` callbacks will need to be modified to throw errors in an acceptable format (`BackgroundRequestError`)
