### PR TITLE
Add Breakpoint Deletion UI

### DIFF
--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Accordion, AccordionSummary, Typography, List, ListItem, ListItemText, AccordionDetails, CircularProgress } from "@material-ui/core";
+import { Accordion, AccordionSummary, Typography, List, ListItem, ListItemText, AccordionDetails, CircularProgress, Divider, AccordionActions, Button } from "@material-ui/core";
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { Variable } from "../../common/types/debugger";
+import { Variable, Breakpoint } from "../../common/types/debugger";
 
 /** Used to display a breakpoint that has not yet hit. */
 export const PendingBreakpointView = ({ breakpointMeta }) => {
@@ -16,7 +16,7 @@ export const PendingBreakpointView = ({ breakpointMeta }) => {
 };
 
 /** Used to display data for a breakpoint that has already hit. */
-export const CompletedBreakpointView = ({ breakpoint }) => {
+export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: {breakpoint: Breakpoint}) => {
   const {stackFrames, location} = breakpoint;
   const stackframe = stackFrames[0];
   return (
@@ -27,6 +27,10 @@ export const CompletedBreakpointView = ({ breakpoint }) => {
       <AccordionDetails>
         <VariablesView variables={stackframe.locals}/>
       </AccordionDetails>
+      <Divider/>
+      <AccordionActions>
+        <Button size="small" color="secondary" onClick={() => deleteBreakpoint(breakpoint.id)}>Delete</Button>
+      </AccordionActions>
     </Accordion>
   )
 };

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -15,8 +15,13 @@ export const PendingBreakpointView = ({ breakpointMeta }) => {
   );
 };
 
+interface CompletedBreakpointViewProps {
+  breakpoint: Breakpoint;
+  /** Callback to delete a breakpoint from cloud debugger. */
+  deleteBreakpoint: (breakpointId: string) => void;
+}
 /** Used to display data for a breakpoint that has already hit. */
-export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: {breakpoint: Breakpoint}) => {
+export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: CompletedBreakpointViewProps) => {
   const {stackFrames, location} = breakpoint;
   const stackframe = stackFrames[0];
   return (

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -26,6 +26,7 @@ interface ChatheadProps {
   setProject: (projectId: string) => void;
   setDebuggee: (debuggeeId: string) => void;
   createBreakpoint: (fileName: string, lineNumber: number) => void;
+  deleteBreakpoint: (breakpointId: string) => void;
 }
 
 interface ChatheadState {}
@@ -79,7 +80,7 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
         }
 
         {
-          this.props.completedBreakpoints.map(b => <CompletedBreakpointView breakpoint={b}/>)
+          this.props.completedBreakpoints.map(b => <CompletedBreakpointView breakpoint={b} deleteBreakpoint={this.props.deleteBreakpoint}/>)
         }
       </ChatheadWrapper>
     );

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -49,7 +49,7 @@ interface InjectedAppState {
   lineNum: number;
   fileName: string;
   activeBreakpoints: { [key: string]: BreakpointMeta };
-  completedBreakpointsList: Array<any>;
+  completedBreakpoints: { [key: string]: Breakpoint };
 }
 
 export class InjectedApp extends React.Component<any,InjectedAppState> {
@@ -64,7 +64,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
       lineNumber: 29,
       fileName: "index.js",
       activeBreakpoints : {},
-      completedBreakpointsList: []
+      completedBreakpoints: {}
     }
   }
 
@@ -178,7 +178,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
    */
   async loadBreakpoints(breakpointIdsToLoad: Array<any>) {
     // Make request to get the breakpoint data using breakpoint ids
-    var tempGetBreakpoints = this.state.completedBreakpointsList.slice();
+    var tempGetBreakpoints = {...this.state.completedBreakpoints};
     var updatedActiveBPs = { ...this.state.activeBreakpoints };
     for (let breakpointId of breakpointIdsToLoad) {
       const getBreakpointresponse = await new BackgroundRequest.FetchBreakpointRequest().run(
@@ -188,11 +188,12 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
         )
       );
       // Add it to the state array for getBreakpoint data
-      tempGetBreakpoints.push(getBreakpointresponse.breakpoint);
+      const {breakpoint} = getBreakpointresponse;
+      tempGetBreakpoints[breakpoint.id] = breakpoint;
       // Remove the breakpoint from the active breakpoint list
       delete updatedActiveBPs[breakpointId];
     }
-    this.setState({ completedBreakpointsList: tempGetBreakpoints });
+    this.setState({ completedBreakpoints: tempGetBreakpoints });
     this.setState({ activeBreakpoints: updatedActiveBPs });
   }
 
@@ -201,7 +202,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
      *  However, as far as UI is concerned, they are both lists. This conversion helps simplify markup.
      */
     const activeBreakpoints = Object.values(this.state.activeBreakpoints);
-    const completedBreakpoints = this.state.completedBreakpointsList;
+    const completedBreakpoints = Object.values(this.state.completedBreakpoints);
 
     return (
       <>

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -163,6 +163,14 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
     }, 5000);
   }
 
+  /** Deletes a breakpoint from debugger backend. */
+  async deleteBreakpoint(breakpointId: string) {
+    const deleteBreakpointRequest = await new BackgroundRequest.DeleteBreakpointRequest().run(
+      new BackgroundRequest.DeleteBreakpointRequestData(this.state.debuggeeId, breakpointId)
+    );
+    alert("Deleted");
+  }
+
   /**
    * This function gets the data of non-active breakpoints (breakpoint that are hit)
    * and saves it to the getBreakpoint state array. Moreover removes it from active breakpoint array.
@@ -211,6 +219,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
           createBreakpoint={(fileName, lineNumber) =>
             this.createBreakPoint(fileName, lineNumber)
           }
+          deleteBreakpoint={(breakpointId: string) => this.deleteBreakpoint(breakpointId)}
         />
 
         <BreakpointMarkers

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -165,10 +165,14 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
 
   /** Deletes a breakpoint from debugger backend. */
   async deleteBreakpoint(breakpointId: string) {
+    // Delete the breakpoint from remote cloud debugger.
     const deleteBreakpointRequest = await new BackgroundRequest.DeleteBreakpointRequest().run(
       new BackgroundRequest.DeleteBreakpointRequestData(this.state.debuggeeId, breakpointId)
     );
-    alert("Deleted");
+    // Remove breakpoint from local tracking.
+    const updatedCompletedBreakpoints = {...this.state.completedBreakpoints};
+    delete updatedCompletedBreakpoints[breakpointId];
+    this.setState({completedBreakpoints: updatedCompletedBreakpoints});
   }
 
   /**


### PR DESCRIPTION
**Background**
- API methods to delete breakpoint already exist, were not integrated with UI.

**Work Done**
- Refactor completedBreakpoints into object to allow deletion of specific IDs
- Add UI to delete breakpoint, and logic to delete on both backend and client.