### PR TITLE
Add tests for breakpoint views

### DIFF
--- a/app/__tests__/chathead/breakpointView.tsx
+++ b/app/__tests__/chathead/breakpointView.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { shallow, mount, render, configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { FailedBreakpoint } from "../../src/common/types/debugger";
+import { FailedBreakpoint, BreakpointMeta } from "../../src/common/types/debugger";
 import { getBreakpointErrorMessage } from "../../src/client/chathead/BreakpointView";
+import { LocationView } from "../../src/client/chathead/BreakpointView";
+
 
 configure({ adapter: new Adapter() });
 
@@ -10,6 +12,7 @@ configure({ adapter: new Adapter() });
 describe("getBreakpointErrorMessage", () => {
   it("performs string substitution", () => {
     const mockBreakpoint: Partial<FailedBreakpoint> = {
+      isError: true,
       status: {
         description: {
           format: "Hello $0 and $1.",
@@ -17,7 +20,18 @@ describe("getBreakpointErrorMessage", () => {
         }
       }
     }
-    const message = getBreakpointErrorMessage(mockBreakpoint);
+    const message = getBreakpointErrorMessage(mockBreakpoint as FailedBreakpoint);
     expect(message).toBe("Hello foo and bar.");
   });
+});
+
+describe("LocationView", () => {
+  const mockBreakpoint: Partial<BreakpointMeta> = {
+    location: {
+      path: "foo.java",
+      line: 24
+    }
+  }
+  const wrapper = shallow(<LocationView breakpoint={mockBreakpoint}/>);
+  expect(wrapper.text()).toBe("foo.java:24");
 });

--- a/app/__tests__/chathead/breakpointView.tsx
+++ b/app/__tests__/chathead/breakpointView.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { shallow, mount, render, configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { FailedBreakpoint } from "../../src/common/types/debugger";
+import { getBreakpointErrorMessage } from "../../src/client/chathead/BreakpointView";
+
+configure({ adapter: new Adapter() });
+
+
+describe("getBreakpointErrorMessage", () => {
+  it("performs string substitution", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      status: {
+        description: {
+          format: "Hello $0 and $1.",
+          parameters: ["foo", "bar"]
+        }
+      }
+    }
+    const message = getBreakpointErrorMessage(mockBreakpoint);
+    expect(message).toBe("Hello foo and bar.");
+  });
+});

--- a/app/__tests__/chathead/breakpointView.tsx
+++ b/app/__tests__/chathead/breakpointView.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { shallow, mount, render, configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { FailedBreakpoint, BreakpointMeta } from "../../src/common/types/debugger";
-import { getBreakpointErrorMessage } from "../../src/client/chathead/BreakpointView";
-import { LocationView } from "../../src/client/chathead/BreakpointView";
+import { FailedBreakpoint, BreakpointMeta, Breakpoint } from "../../src/common/types/debugger";
+import { getBreakpointErrorMessage, FailedCompletedBreakpointView, CompletedBreakpointView } from "../../src/client/chathead/BreakpointView";
+import { LocationView, PendingBreakpointView, SuccessfulCompletedBreakpointView, VariablesView} from "../../src/client/chathead/BreakpointView";
+import { AccordionSummary, CircularProgress, Accordion, AccordionDetails } from "@material-ui/core";
 
 
 configure({ adapter: new Adapter() });
@@ -12,8 +13,8 @@ configure({ adapter: new Adapter() });
 describe("getBreakpointErrorMessage", () => {
   it("performs string substitution", () => {
     const mockBreakpoint: Partial<FailedBreakpoint> = {
-      isError: true,
       status: {
+        isError: true,
         description: {
           format: "Hello $0 and $1.",
           parameters: ["foo", "bar"]
@@ -34,4 +35,187 @@ describe("LocationView", () => {
   }
   const wrapper = shallow(<LocationView breakpoint={mockBreakpoint}/>);
   expect(wrapper.text()).toBe("foo.java:24");
+});
+
+describe("PendingBreakpointView", () => {
+  it("is accordion", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      }
+    }
+  
+    const wrapper = mount(<PendingBreakpointView breakpointMeta={mockBreakpoint}/>);
+    expect(wrapper.find(Accordion).exists()).toBe(true);
+  });
+
+  it("shows location", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      }
+    }
+  
+    const wrapper = mount(<PendingBreakpointView breakpointMeta={mockBreakpoint}/>);
+    expect(wrapper.find(LocationView).exists()).toBe(true);
+  });
+
+  it("shows loading status", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      }
+    }
+  
+    const wrapper = mount(<PendingBreakpointView breakpointMeta={mockBreakpoint}/>);
+    expect(wrapper.find(CircularProgress).exists()).toBe(true);
+  });
+});
+
+
+describe("SuccessfulCompletedBreakpointView", () => {
+  it("is accordion", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      stackFrames: [{locals: []}]
+    }
+  
+    const wrapper = mount(<SuccessfulCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(Accordion).exists()).toBe(true);
+  });
+
+  it("shows location", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      stackFrames: [{locals: []}]
+    }
+  
+    const wrapper = mount(<SuccessfulCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(LocationView).exists()).toBe(true);
+  });
+
+  it("shows variables when expanded", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      stackFrames: [{locals: []}]
+    }
+  
+    const wrapper = shallow(<SuccessfulCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(
+      wrapper.find(AccordionDetails)
+             .dive()
+             .find(VariablesView).exists()
+    ).toBe(true);
+  });
+});
+
+describe("FailedCompletedBreakpointView", () => {
+  it("is accordion", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      status: {
+        isError: true,
+        description: {
+          format: "Hello $0 and $1.",
+          parameters: ["foo", "bar"]
+        }
+      }
+    }
+  
+    const wrapper = mount(<FailedCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(Accordion).exists()).toBe(true);
+  });
+
+  it("shows location", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      status: {
+        isError: true,
+        description: {
+          format: "Hello $0 and $1.",
+          parameters: ["foo", "bar"]
+        }
+      }
+    }
+  
+    const wrapper = mount(<FailedCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(LocationView).exists()).toBe(true);
+  });
+
+  it("shows error message", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      status: {
+        isError: true,
+        description: {
+          format: "Hello $0 and $1.",
+          parameters: ["foo", "bar"]
+        }
+      }
+    }
+  
+    const wrapper = shallow(<FailedCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.html()).toContain("MuiAlert-standardError");
+    expect(wrapper.text()).toContain("Hello foo and bar.");
+  });
+});
+
+describe("CompletedBreakpointView", () => {
+  it("displays a successful breakpoint view if no status is provided.", () => {
+    const mockBreakpoint: Partial<Breakpoint> = {
+      
+    };
+
+    const wrapper = shallow(<CompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(SuccessfulCompletedBreakpointView).exists()).toBe(true);
+  });
+
+  it("displays a successful breakpoint view if status isError is false.", () => {
+    const mockBreakpoint: Partial<Breakpoint> = {
+      status: {isError: false}
+    };
+
+    const wrapper = shallow(<CompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(SuccessfulCompletedBreakpointView).exists()).toBe(true);
+  });
+
+  it("displays a failed breakpoint view if status isError.", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      status: {
+        isError: true,
+        description: {
+          format: "",
+          parameters: []
+        }
+      },
+      location: {
+        path: "foo.java",
+        line: 24
+      }
+    };
+
+    const wrapper = mount(<FailedCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(FailedCompletedBreakpointView).exists()).toBe(true);
+  });
 });

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -7,11 +7,10 @@ import { Variable, Breakpoint, FailedBreakpoint } from "../../common/types/debug
 
 /** Used to display a breakpoint that has not yet hit. */
 export const PendingBreakpointView = ({ breakpointMeta }) => {
-  const {location} = breakpointMeta;
   return (
     <Accordion>
       <AccordionSummary disabled expandIcon={<CircularProgress/>}>
-        <Typography>{location.path}:{location.line}</Typography>
+        <LocationView breakpoint={breakpointMeta}/>
       </AccordionSummary>
     </Accordion>
   );
@@ -19,7 +18,6 @@ export const PendingBreakpointView = ({ breakpointMeta }) => {
 
 /** Used to display data for a breakpoint that has already hit. */
 export const CompletedBreakpointView = ({ breakpoint }) => {
-  console.log(breakpoint);
   const {status} = breakpoint;
   if (status && status.isError) {
     return <FailedCompletedBreakpointView breakpoint={breakpoint}/>;
@@ -29,12 +27,12 @@ export const CompletedBreakpointView = ({ breakpoint }) => {
 
 /** Shows stackframe data for a successful breakpoint. */
 export const SuccessfulCompletedBreakpointView = ({breakpoint}) => {
-  const {stackFrames, location} = breakpoint;
+  const {stackFrames} = breakpoint;
   const stackframe = stackFrames[0];
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
-        <Typography>{location.path}:{location.line}</Typography>
+        <LocationView breakpoint={breakpoint}/>
       </AccordionSummary>
       <AccordionDetails>
         <VariablesView variables={stackframe.locals}/>
@@ -45,12 +43,10 @@ export const SuccessfulCompletedBreakpointView = ({breakpoint}) => {
 
 /** Shows error data for a failed breakpoint. */
 export const FailedCompletedBreakpointView = ({breakpoint}) => {
-  const {location} = breakpoint;
-
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ErrorIcon/>}>
-        <Typography>{location.path}:{location.line}</Typography>
+        <LocationView breakpoint={breakpoint}/>
       </AccordionSummary>
       <AccordionDetails>
         <Alert severity="error">
@@ -88,4 +84,12 @@ const VariablesView = ({variables}: {variables: Variable[]}) => {
       }
     </List>
   )
+}
+
+/** Displays file name and line number for a breakpoint. */
+export const LocationView = ({breakpoint}) => {
+  const {location} = breakpoint;
+  return (
+    <Typography>{location.path}:{location.line}</Typography>
+  );
 }

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -71,7 +71,7 @@ export function getBreakpointErrorMessage(breakpoint: FailedBreakpoint): string{
   const {status} = breakpoint;
   const {format, parameters} = status.description;
   // This Regex looks for sequences like $0, $1, ... and replaces them with the parameter for their index.
-  const message = format.replace(/\$({\d}+)/, (match, index) => parameters[index]);
+  const message = format.replace(/\$(\d+)/g, (match, index) => parameters[index]);
   return message;
 }
 

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -72,7 +72,7 @@ export function getBreakpointErrorMessage(breakpoint: FailedBreakpoint): string{
 }
 
 /** Displays a set of variables from a debugger stack frame. */
-const VariablesView = ({variables}: {variables: Variable[]}) => {
+export const VariablesView = ({variables}: {variables: Variable[]}) => {
   return (
     <List dense>
       {

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -3,7 +3,7 @@ import { Accordion, AccordionSummary, Typography, List, ListItem, ListItemText, 
 import { Alert, AlertTitle } from "@material-ui/lab";
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ErrorIcon from '@material-ui/icons/Error';
-import { Variable } from "../../common/types/debugger";
+import { Variable, Breakpoint, FailedBreakpoint } from "../../common/types/debugger";
 
 /** Used to display a breakpoint that has not yet hit. */
 export const PendingBreakpointView = ({ breakpointMeta }) => {
@@ -45,12 +45,8 @@ export const SuccessfulCompletedBreakpointView = ({breakpoint}) => {
 
 /** Shows error data for a failed breakpoint. */
 export const FailedCompletedBreakpointView = ({breakpoint}) => {
-  const {location, status} = breakpoint;
-  // Debugger returns the error message in the form of a bash style template string.
-  // Example: format = "Hello $0", parameters = ["Bob"]
-  const {format, parameters} = status.description;
-  // This Regex looks for sequences like $0, $1, ... and replaces them with the parameter for their index.
-  const message = format.replace(/\$({\d}+)/, (match, index) => parameters[index]);
+  const {location} = breakpoint;
+
   return (
     <Accordion defaultExpanded>
       <AccordionSummary expandIcon={<ErrorIcon/>}>
@@ -60,11 +56,23 @@ export const FailedCompletedBreakpointView = ({breakpoint}) => {
         <Alert severity="error">
           {/* Currently this title causes issues with the width of the chathead */}
           {/* <AlertTitle>{status.refersTo}</AlertTitle> */}
-          {message}
+          {getBreakpointErrorMessage(breakpoint)}
         </Alert>
       </AccordionDetails>
     </Accordion>
   );
+}
+
+/**
+ * Debugger returns the error message in the form of a bash style template string.
+ * Example: format = "Hello $0", parameters = ["Bob"]
+ */
+export function getBreakpointErrorMessage(breakpoint: FailedBreakpoint): string{
+  const {status} = breakpoint;
+  const {format, parameters} = status.description;
+  // This Regex looks for sequences like $0, $1, ... and replaces them with the parameter for their index.
+  const message = format.replace(/\$({\d}+)/, (match, index) => parameters[index]);
+  return message;
 }
 
 /** Displays a set of variables from a debugger stack frame. */

--- a/app/src/common/types/debugger.ts
+++ b/app/src/common/types/debugger.ts
@@ -22,6 +22,19 @@ export interface Breakpoint extends BreakpointMeta {
     labels: any;
 }
 
+/** A breakpoint that has completed with errors. */
+export interface FailedBreakpoint extends Breakpoint {
+  status: {
+    isError: boolean;
+    // Debugger returns the error message in the form of a bash style template string.
+    // Example: format = "Hello $0", parameters = ["Bob"]
+    description: {
+      format: string;
+      parameters: string[]
+    }
+  }
+}
+
 /* A single GCP project */
 export interface Project {
     projectNumber: string;


### PR DESCRIPTION
**Background**
We've been working to meet deadlines lately, and test coverage has suffered. Now, there's some time leftover to deal with this.
One area with particularly low coverage is the BreakpointViews file, which has a selection of UI components to display breakpoints in various lifecycle stages in the chathead.

**Work Done**
Created tests (primarily around structural UI validation) for each lifecycle of breakpoint views.
**Out of Scope**
- Injected breakpoint markers
- Errors that may arise while loading breakpoints, or going from a list of breakpoints to a list of breakpoint views. This only considers the presentation of a single breakpoint object after loading