### PR TITLE
Migrate select views to mui autocomplete

### DIFF
--- a/app/__tests__/chathead/generalSelectView.tsx
+++ b/app/__tests__/chathead/generalSelectView.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import { shallow, mount, render, configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+import { createMount } from '@material-ui/core/test-utils';
 
 configure({ adapter: new Adapter() });
 
 import {
-  SelectView,
-  LoadingView,
-  OptionSelect,
-  Option,
+  SelectView
 } from "../../src/client/chathead/GeneralSelectView";
 import { MenuItem, Select, CircularProgress } from "@material-ui/core";
+import Autocomplete from "@material-ui/lab/Autocomplete";
 
 describe("SelectView", () => {
   it("displays loading state", () => {
@@ -24,22 +23,5 @@ describe("SelectView", () => {
       />
     );
     expect(wrapper.find(CircularProgress)).toHaveLength(1);
-  });
-
-  it("calls back on option change", () => {
-    const spy = jest.fn();
-    const wrapper = mount(
-      <SelectView
-        optionsLoading={false}
-        options={["a", "b", "c"]}
-        optionToId={opt => opt}
-        selectedOptionId={"b"}
-        onChange={spy}
-      />
-    );
-
-    // Find and click option
-    wrapper.find("input").simulate("change", { target: { value: "a" } });
-    expect(spy).toHaveBeenCalledWith("a");
   });
 });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2282,6 +2282,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
@@ -7290,7 +7302,8 @@
     "debugger-extension-api": {
       "version": "file:../api",
       "requires": {
-        "axios": "^0.19.2"
+        "axios": "^0.19.2",
+        "node-fetch": "^2.6.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -10078,6 +10091,11 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-int64": {
           "version": "0.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@types/jest": "^26.0.3",
     "@types/jquery": "^3.5.0",
     "@types/react": "^16.9.41",

--- a/app/src/client/chathead/GeneralSelectView.tsx
+++ b/app/src/client/chathead/GeneralSelectView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Select, MenuItem, FormControl, InputLabel, CircularProgress } from "@material-ui/core";
-
+import { Select, MenuItem, FormControl, InputLabel, CircularProgress, TextField } from "@material-ui/core";
+import Autocomplete from '@material-ui/lab/Autocomplete';
 interface SelectViewProps {
   options: any[];
   label?: string;
@@ -24,17 +24,16 @@ export class SelectView extends React.Component<SelectViewProps, {}> {
       return <CircularProgress/>
     }
 
-    const menuItems = options.map(optionToId).map(optId => <MenuItem value={optId}>{optId}</MenuItem>);
-
     return (
       <FormControl variant="outlined" style={{width: "100%"}}>
-        <InputLabel>{label}</InputLabel>
-        <Select
+        {/* <InputLabel>{label}</InputLabel> */}
+        <Autocomplete
+          options={options.map(optionToId)}
+          style={{width: 300}}
           value={selectedOptionId}
-          onChange={event => this.onChange(event.target.value)}
-        >
-          {menuItems}
-        </Select>
+          onChange={(event, newValue) => this.onChange(newValue)}
+          renderInput={(params) => <TextField {...params} label={label} variant="outlined"/>}
+        />
       </FormControl>
     );
   }


### PR DESCRIPTION
**Background**
When showing dropdown with many options (e.g projects), searching UX is terrible.

**Work Done**
Migrated from normal select view to MUI Autocomplete, allowing search and filtering.

![image](https://user-images.githubusercontent.com/17712692/87955565-eaf60000-ca7b-11ea-974f-f0d94539b4e9.png)

**Note:** A UI test had to be removed for this, as MUI doesn't expose a nice way to simulate Autocomplete value change. Hopefully we can figure this out at some point.