### PR TITLE
Fix undefined projectId saves

### DIFF
--- a/app/__tests__/injected-app/injected-app.tsx
+++ b/app/__tests__/injected-app/injected-app.tsx
@@ -35,4 +35,61 @@ describe("Injected App", () => {
       expect(InjectedApp.prototype.getProjectNameFromGithub).toHaveBeenCalled();
     });
 });
+
+describe("Saving Project IDs", () => {
+  const localStorageMock = {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn()
+  };
+
+  let getProjectNameMock: jest.SpyInstance;
+
+  beforeAll(() => {
+    getProjectNameMock = jest.spyOn(InjectedApp.prototype, "getProjectNameFromGithub");
+  });
+
+  afterEach(() => {
+    localStorageMock.setItem.mockClear();
+    localStorageMock.getItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+
+    getProjectNameMock.mockClear();
+  });
+
+  afterAll(() => {
+    getProjectNameMock.mockRestore();
+  });
+
+  it("sets if projectId defined and projectName defined", () => {
+    getProjectNameMock.mockReturnValue("projectName");
+    const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
+    wrapper.instance().saveGcpProjectId("projectId");
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("projectName", "projectId");
+  });
+
+  it("does not set if projectId defined and projectName not defined", () => {
+    getProjectNameMock.mockReturnValue(undefined);
+    const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
+    wrapper.instance().saveGcpProjectId("projectId");
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("does not set if projectId not defined and projectName not defined", () => {
+    getProjectNameMock.mockReturnValue(undefined);
+    const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
+    wrapper.instance().saveGcpProjectId(undefined);
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("clears item if projectId not defined and projectName defined", () => {
+    getProjectNameMock.mockReturnValue("projectName");
+    const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
+    wrapper.instance().saveGcpProjectId(undefined);
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith("projectName")
+  });
+});
   

--- a/app/__tests__/injected-app/injected-app.tsx
+++ b/app/__tests__/injected-app/injected-app.tsx
@@ -64,14 +64,14 @@ describe("Saving Project IDs", () => {
   it("sets if projectId defined and projectName defined", () => {
     getProjectNameMock.mockReturnValue("projectName");
     const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
-    wrapper.instance().saveGcpProjectId("projectId");
+    (wrapper.instance() as InjectedApp).saveGcpProjectId("projectId");
     expect(localStorageMock.setItem).toHaveBeenCalledWith("projectName", "projectId");
   });
 
   it("does not set if projectId defined and projectName not defined", () => {
     getProjectNameMock.mockReturnValue(undefined);
     const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
-    wrapper.instance().saveGcpProjectId("projectId");
+    (wrapper.instance() as InjectedApp).saveGcpProjectId("projectId");
     expect(localStorageMock.setItem).not.toHaveBeenCalled();
     expect(localStorageMock.removeItem).not.toHaveBeenCalled();
   });
@@ -79,7 +79,7 @@ describe("Saving Project IDs", () => {
   it("does not set if projectId not defined and projectName not defined", () => {
     getProjectNameMock.mockReturnValue(undefined);
     const wrapper = shallow(<InjectedApp localStorage={localStorageMock}/>); 
-    wrapper.instance().saveGcpProjectId(undefined);
+    (wrapper.instance() as InjectedApp).saveGcpProjectId(undefined);
     expect(localStorageMock.setItem).not.toHaveBeenCalled();
     expect(localStorageMock.removeItem).not.toHaveBeenCalled();
   });

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -11,6 +11,8 @@ interface InjectedAppState {
 
   activeBreakpoints: { [key: string]: BreakpointMeta };
   completedBreakpoints: { [key: string]: Breakpoint };
+
+  localStorage?: Storage
 }
 
 export class InjectedApp extends React.Component<any,InjectedAppState> {
@@ -41,7 +43,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
    * This function checks of the project name already exists in the local storage 
    */
   getGcpProjectId(): string{
-    let gcpProjectId = localStorage.getItem(this.getProjectNameFromGithub());
+    let gcpProjectId = this.getLocalStorage().getItem(this.getProjectNameFromGithub());
     return gcpProjectId !== null ? gcpProjectId : undefined;
   }
 
@@ -53,10 +55,10 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
       // Save new project ID only if there is a projectId.
       // Otherwise, localStorage saves the string "undefined" which throws things off.
       if (projectId) {
-        localStorage.setItem(projectName, projectId);
+        this.getLocalStorage().setItem(projectName, projectId);
       } else {
         // In the undefined case, manually remove the saved project.
-        localStorage.removeItem(projectName);
+        this.getLocalStorage().removeItem(projectName);
       }
     }
   }
@@ -111,7 +113,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
         let inactiveBreakpoints: Array<any> = [];
         for (let breakpointId in this.state.activeBreakpoints) {
           if (!breakpointList.includes(breakpointId)) {
-            inactiveBreakpoints.push(brseakpointId);
+            inactiveBreakpoints.push(breakpointId);
           }
         }
 
@@ -194,6 +196,11 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
         />
       </>
     );
+  }
+
+  /** Get the windows local storage object. This accepts a prop to allow mocks. */
+  getLocalStorage() {
+    return this.props.localStorage || window.localStorage;
   }
 }
 

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -45,6 +45,22 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
     return gcpProjectId !== null ? gcpProjectId : undefined;
   }
 
+  /** Saves the current project name - project id association (if possible) */
+  saveGcpProjectId(projectId: string): void {
+    const projectName = this.getProjectNameFromGithub();
+    // Only save if we're able to pull the project name.
+    if (projectName) {
+      // Save new project ID only if there is a projectId.
+      // Otherwise, localStorage saves the string "undefined" which throws things off.
+      if (projectId) {
+        localStorage.setItem(projectName, projectId);
+      } else {
+        // In the undefined case, manually remove the saved project.
+        localStorage.removeItem(projectName);
+      }
+    }
+  }
+
   /**
    * Makes request to the BackgroundRequest to set the breakpoint
    * using debuggee id, file name and line number
@@ -159,19 +175,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
           activeBreakpoints={activeBreakpoints}
           completedBreakpoints={completedBreakpoints}
           setProject={(projectId) => {
-            const projectName = this.getProjectNameFromGithub();
-            // Only save if we're able to pull the project name.
-            if (projectName) {
-              // Save new project ID only if there is a projectId.
-              // Otherwise, localStorage saves the string "undefined" which throws things off.
-              if (projectId) {
-                localStorage.setItem(projectName, projectId);
-              } else {
-                // In the undefined case, manually remove the saved project.
-                localStorage.removeItem(projectName);
-              }
-            }
-            
+            this.saveGcpProjectId(projectId);
             this.setState({projectId})}
           }
           setDebuggee={(debuggeeId) => this.setState({ debuggeeId })}

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -159,7 +159,19 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
           activeBreakpoints={activeBreakpoints}
           completedBreakpoints={completedBreakpoints}
           setProject={(projectId) => {
-            localStorage.setItem(this.getProjectNameFromGithub(), projectId);
+            const projectName = this.getProjectNameFromGithub();
+            // Only save if we're able to pull the project name.
+            if (projectName) {
+              // Save new project ID only if there is a projectId.
+              // Otherwise, localStorage saves the string "undefined" which throws things off.
+              if (projectId) {
+                localStorage.setItem(projectName, projectId);
+              } else {
+                // In the undefined case, manually remove the saved project.
+                localStorage.removeItem(projectName);
+              }
+            }
+            
             this.setState({projectId})}
           }
           setDebuggee={(debuggeeId) => this.setState({ debuggeeId })}

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -111,7 +111,7 @@ export class InjectedApp extends React.Component<any,InjectedAppState> {
         let inactiveBreakpoints: Array<any> = [];
         for (let breakpointId in this.state.activeBreakpoints) {
           if (!breakpointList.includes(breakpointId)) {
-            inactiveBreakpoints.push(breakpointId);
+            inactiveBreakpoints.push(brseakpointId);
           }
         }
 


### PR DESCRIPTION
**Background**
If projectId is undefined (because it hasn't been set yet), it will be saved as the *string* 'undefined. This means on next load, it'll treat 'undefined' as the projectId.

**Work Done**
- Added logic to not save if projectId is undefined
- Refactored and added unit tests