### PR TITLE
Feature/prevent setting multiple Breakpoints

### DIFF
--- a/app/__tests__/chathead/createBreakpointForm.tsx
+++ b/app/__tests__/chathead/createBreakpointForm.tsx
@@ -15,7 +15,7 @@ describe("CreateBreakpointForm", () => {
 
   it("handles input", () => {
     const wrapper = shallow(
-      <CreateBreakpointForm createBreakpoint={() => {}} />
+      <CreateBreakpointForm activeBreakpoints={[]} createBreakpoint={() => {}} />
     );
     const fileNameInput = wrapper.find('[data-testid="fileName"]');
     const lineNumberInput = wrapper.find('[data-testid="lineNumber"]');
@@ -36,10 +36,7 @@ describe("CreateBreakpointForm", () => {
     );
     (wrapper.instance() as CreateBreakpointForm).onFileName("a");
     (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
-    // wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
-    wrapper
-      .find(Button)
-      .simulate("click", { preventDefault: preventFormSubmitSpy });
+    wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
 
     expect(spy).toHaveBeenCalledWith("a", 1);
     expect(preventFormSubmitSpy).toHaveBeenCalled();
@@ -48,14 +45,14 @@ describe("CreateBreakpointForm", () => {
   it("calls DeleteAllActiveBreakpoint", () => {
     const spy = jest.fn();
     const preventFormSubmitSpy = jest.fn();
-    const wrapper = shallow(<CreateBreakpointForm deleteAllActiveBreakpoints={spy} />);
+    const wrapper = shallow(<CreateBreakpointForm activeBreakpoints={[]} deleteAllActiveBreakpoints={spy} />);
     wrapper.find("#deleteActiveBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
 
     expect(spy).toHaveBeenCalled();
     expect(preventFormSubmitSpy).toHaveBeenCalled();
   });
 
-  it("Prevents from creating breakpoint if breakpoint already existed", () => {
+  it("Prevents from creating breakpoint if breakpoint already existed in active BP list", () => {
     const spy = jest.fn();
     const preventFormSubmitSpy = jest.fn();
     const temp = {
@@ -72,11 +69,43 @@ describe("CreateBreakpointForm", () => {
     );
     (wrapper.instance() as CreateBreakpointForm).onFileName("a");
     (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
-    wrapper
-      .find(Button)
-      .simulate("click", { preventDefault: preventFormSubmitSpy });
+    wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
+
 
     expect(spy).not.toHaveBeenCalled();
     expect(preventFormSubmitSpy).toHaveBeenCalled();
   });
+
+  it("Prevents from creating breakpoint if breakpoint already existed in Completed BP list", () => {
+    const spy = jest.fn();
+    const preventFormSubmitSpy = jest.fn();
+    const temp = {
+      id: "string",
+      location: {
+        path: "a",
+        line: 1,
+      },
+      createTime: "string",
+      userEmail: "string",
+      isFinalState: true,
+      stackFrames: [],
+      variableTable: [],
+      finalTime: "string",
+      labels: "any"
+    };
+    const wrapper = shallow(
+      <CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[]} completedBreakpoints={[temp]} />
+    );
+    (wrapper.instance() as CreateBreakpointForm).onFileName("a");
+    (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
+    wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
+
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(preventFormSubmitSpy).toHaveBeenCalled();
+  });
+
+
+
+
 });

--- a/app/__tests__/chathead/createBreakpointForm.tsx
+++ b/app/__tests__/chathead/createBreakpointForm.tsx
@@ -31,10 +31,15 @@ describe("CreateBreakpointForm", () => {
   it("calls createBreakpoint", () => {
     const spy = jest.fn();
     const preventFormSubmitSpy = jest.fn();
-    const wrapper = shallow(<CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[]}/>);
+    const wrapper = shallow(
+      <CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[]} />
+    );
     (wrapper.instance() as CreateBreakpointForm).onFileName("a");
     (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
-    wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
+    // wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
+    wrapper
+      .find(Button)
+      .simulate("click", { preventDefault: preventFormSubmitSpy });
 
     expect(spy).toHaveBeenCalledWith("a", 1);
     expect(preventFormSubmitSpy).toHaveBeenCalled();
@@ -50,4 +55,28 @@ describe("CreateBreakpointForm", () => {
     expect(preventFormSubmitSpy).toHaveBeenCalled();
   });
 
+  it("Prevents from creating breakpoint if breakpoint already existed", () => {
+    const spy = jest.fn();
+    const preventFormSubmitSpy = jest.fn();
+    const temp = {
+      id: "string",
+      location: {
+        path: "a",
+        line: 1,
+      },
+      createTime: "string",
+      userEmail: "string",
+    };
+    const wrapper = shallow(
+      <CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[temp]} />
+    );
+    (wrapper.instance() as CreateBreakpointForm).onFileName("a");
+    (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
+    wrapper
+      .find(Button)
+      .simulate("click", { preventDefault: preventFormSubmitSpy });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(preventFormSubmitSpy).toHaveBeenCalled();
+  });
 });

--- a/app/__tests__/chathead/createBreakpointForm.tsx
+++ b/app/__tests__/chathead/createBreakpointForm.tsx
@@ -14,31 +14,40 @@ describe("CreateBreakpointForm", () => {
   });
 
   it("handles input", () => {
+    const fileName = "a";
+    const lineNumber = 1;
+
+
     const wrapper = shallow(
       <CreateBreakpointForm activeBreakpoints={[]} createBreakpoint={() => {}} />
     );
     const fileNameInput = wrapper.find('[data-testid="fileName"]');
     const lineNumberInput = wrapper.find('[data-testid="lineNumber"]');
-    fileNameInput.simulate("change", { target: { value: "a" } });
-    lineNumberInput.simulate("change", { target: { value: 1 } });
+    fileNameInput.simulate("change", { target: { value: fileName } });
+    lineNumberInput.simulate("change", { target: { value: lineNumber } });
 
-    expect(wrapper.state()).toEqual({
-      fileName: "a",
-      lineNumber: 1,
+    expect(wrapper.state()).toMatchObject({
+      fileName,
+      lineNumber,
     });
   });
 
   it("calls createBreakpoint", () => {
     const spy = jest.fn();
     const preventFormSubmitSpy = jest.fn();
-    const wrapper = shallow(
-      <CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[]} />
-    );
-    (wrapper.instance() as CreateBreakpointForm).onFileName("a");
-    (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
+
+    const fileName = "a";
+    const lineNumber = 1;
+    const condition = "";
+    const expressions = [];
+ 
+
+    const wrapper = shallow(<CreateBreakpointForm activeBreakpoints={[]} createBreakpoint={spy} completedBreakpoints={[]} />);
+    (wrapper.instance() as CreateBreakpointForm).onFileName(fileName);
+    (wrapper.instance() as CreateBreakpointForm).onLineNumber(lineNumber);
     wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});
 
-    expect(spy).toHaveBeenCalledWith("a", 1);
+    expect(spy).toHaveBeenCalledWith(fileName, lineNumber);
     expect(preventFormSubmitSpy).toHaveBeenCalled();
   });
 

--- a/app/__tests__/chathead/createBreakpointForm.tsx
+++ b/app/__tests__/chathead/createBreakpointForm.tsx
@@ -31,7 +31,7 @@ describe("CreateBreakpointForm", () => {
   it("calls createBreakpoint", () => {
     const spy = jest.fn();
     const preventFormSubmitSpy = jest.fn();
-    const wrapper = shallow(<CreateBreakpointForm createBreakpoint={spy} />);
+    const wrapper = shallow(<CreateBreakpointForm createBreakpoint={spy} activeBreakpoints={[]}/>);
     (wrapper.instance() as CreateBreakpointForm).onFileName("a");
     (wrapper.instance() as CreateBreakpointForm).onLineNumber(1);
     wrapper.find("#createBpButton").simulate("click", {preventDefault: preventFormSubmitSpy});

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -20,7 +20,7 @@
   },
 
   "oauth2": {
-    "client_id": "975956245065-kiec30fc8k9v7l8bgake6mqhe33aenv9.apps.googleusercontent.com",
+    "client_id": "814996444798-715meputir3nr40tnr5c5t793kkp95aa.apps.googleusercontent.com",
     "scopes": [
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/userinfo.profile"

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -95,10 +95,7 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
                 <Typography variant="h6">Breakpoints</Typography>
               </Toolbar>
             </AppBar>
-            <CreateBreakpointForm
-              createBreakpoint={this.props.createBreakpoint}
-              deleteAllActiveBreakpoints={this.props.deleteAllActiveBreakpoints}
-            />
+            <CreateBreakpointForm activeBreakpoints={this.props.activeBreakpoints} deleteAllActiveBreakpoints={this.props.deleteAllActiveBreakpoints} createBreakpoint={this.props.createBreakpoint}/>
           </>
         )}
 

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -95,7 +95,7 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
                 <Typography variant="h6">Breakpoints</Typography>
               </Toolbar>
             </AppBar>
-            <CreateBreakpointForm activeBreakpoints={this.props.activeBreakpoints} deleteAllActiveBreakpoints={this.props.deleteAllActiveBreakpoints} createBreakpoint={this.props.createBreakpoint}/>
+            <CreateBreakpointForm activeBreakpoints={this.props.activeBreakpoints} completedBreakpoints={this.props.completedBreakpoints}  deleteAllActiveBreakpoints={this.props.deleteAllActiveBreakpoints} createBreakpoint={this.props.createBreakpoint}/>
           </>
         )}
 

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -87,7 +87,6 @@ export class CreateBreakpointForm extends React.Component<
         <Card elevation={1}>
           <CardContent>
             <form>
-              
               <TextField
                 label="File Name"
                 style={{ width: "100%" }}
@@ -108,20 +107,29 @@ export class CreateBreakpointForm extends React.Component<
               />
               <br />
               <br />
-              <Button id='createBpButton'
+              <Button
+                id="createBpButton"
                 onClick={(e) => {
                   e.preventDefault(); // Prevents a page reload from form submit.
                   if (this.checkValidBreakpoint()) {
                     this.onCreateBreakpoint();
                     this.setState({ errorMessage: undefined });
                   } else {
-                    this.setState({ errorMessage: "ERROR" });
+                    this.setState({
+                      errorMessage:
+                        "The breakpoint on file: " +
+                        this.state.fileName +
+                        " and line number: " +
+                        this.state.lineNumber +
+                        " already exists",
+                    });
                   }
                 }}
               >
                 Create Breakpoint
               </Button>
-              <Button id='deleteActiveBpButton'
+              <Button
+                id="deleteActiveBpButton"
                 onClick={(e) => {
                   e.preventDefault(); // Prevents a page reload from form submit.
                   this.onDeleteAllActiveBreakpoints();
@@ -130,21 +138,13 @@ export class CreateBreakpointForm extends React.Component<
               >
                 Delete all active breakpoints
               </Button>
-                { this.state.errorMessage === "ERROR" && (
+              {this.state.errorMessage !== undefined && (
                 <Card>
-                    <CardContent>
-                      {
-                          <Alert severity="error">{                      
-                            "The breakpoint on file: " +
-                          this.state.fileName
-                      } <br/> {" and line number: " +
-                          this.state.lineNumber +
-                          " already exists"}</Alert>
-                      }
-                    </CardContent>
-                  </Card>
-                )
-            }
+                  <CardContent>
+                    <Alert severity="error">{this.state.errorMessage}</Alert>
+                  </CardContent>
+                </Card>
+              )}
             </form>
           </CardContent>
         </Card>

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -45,8 +45,11 @@ export class CreateBreakpointForm extends React.Component<
     this.props.deleteAllActiveBreakpoints();
   }
 
+  /** Checks for the valid breakpoint. If the breakpoint already exists in active or completed list*/
   checkValidBreakpoint() {
+    // Loop through the lists and check active list
     for (let breakpoint of this.props.activeBreakpoints) {
+      // if the breakpoint already exists, return false
       if (
         breakpoint.location.path == this.state.fileName &&
         breakpoint.location.line == this.state.lineNumber
@@ -54,7 +57,7 @@ export class CreateBreakpointForm extends React.Component<
         return false;
       }
     }
-
+    // loop through the completed list and check
     for (let breakpoint of this.props.completedBreakpoints) {
       if (
         breakpoint.location.path == this.state.fileName &&
@@ -67,13 +70,13 @@ export class CreateBreakpointForm extends React.Component<
     return true;
   }
 
+  /** Compares the activeBreakpoint list to update the error message in chathead if existed */
   componentDidUpdate(prevProps) {
     if (this.props.activeBreakpoints.length > prevProps.activeBreakpoints.length) {
       this.setState({ errorMessage: true });
     }
   }
 
-  
 
   render() {
     const { fileName, lineNumber } = this.state;

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { TextField, Card, CardContent, Button, Box } from "@material-ui/core";
+import { BreakpointMeta } from "../../common/types/debugger";
+import Alert from '@material-ui/lab/Alert';
+
 
 interface CreateBreakpointFormProps {
   createBreakpoint: (fileName: string, lineNumber: number) => void;
   deleteAllActiveBreakpoints: () => void;
+  activeBreakpoints: BreakpointMeta[];
+
 }
 
 interface CreateBreakpointFormState {
@@ -38,6 +43,14 @@ export class CreateBreakpointForm extends React.Component<
   onDeleteAllActiveBreakpoints() {
     this.props.deleteAllActiveBreakpoints();
   }
+  checkValidBreakpoint(){
+    for (let breakpoint of this.props.activeBreakpoints) {
+      if (breakpoint.location.path == this.state.fileName && breakpoint.location.line == this.state.lineNumber) {
+          return false;
+      }
+    }
+    return true;
+  }
 
   render() {
     const { fileName, lineNumber } = this.state;
@@ -64,14 +77,15 @@ export class CreateBreakpointForm extends React.Component<
                 onChange={(e) => this.onLineNumber(e.target.value)}
                 variant="outlined"
               />
-              <br />
-              <br />
-              <Button id='createBpButton'
-                onClick={(e) => {
-                  e.preventDefault(); // Prevents a page reload from form submit.
+              <br/><br/>
+              <Button id='createBpButton' onClick={(e) => {
+                e.preventDefault(); // Prevents a page reload from form submit.
+                if (this.checkValidBreakpoint()){
                   this.onCreateBreakpoint();
-                }}
-              >
+                } else {
+                  alert("The breakpoint on file: "+ this.state.fileName + " and line number: "+ this.state.lineNumber+ " already exists");
+                };
+                }}>
                 Create Breakpoint
               </Button>
               <Button id='deleteActiveBpButton'

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -31,10 +31,12 @@ export class CreateBreakpointForm extends React.Component<
 
   onFileName(fileName) {
     this.setState({ fileName });
+    this.setState({ errorMessage: true });
   }
 
   onLineNumber(lineNumber) {
     this.setState({ lineNumber });
+    this.setState({ errorMessage: true });
   }
 
   onCreateBreakpoint() {
@@ -85,6 +87,7 @@ export class CreateBreakpointForm extends React.Component<
         <Card elevation={1}>
           <CardContent>
             <form>
+              
               <TextField
                 label="File Name"
                 style={{ width: "100%" }}
@@ -122,6 +125,7 @@ export class CreateBreakpointForm extends React.Component<
                 onClick={(e) => {
                   e.preventDefault(); // Prevents a page reload from form submit.
                   this.onDeleteAllActiveBreakpoints();
+                  this.setState({ errorMessage: true });
                 }}
               >
                 Delete all active breakpoints

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -13,7 +13,7 @@ interface CreateBreakpointFormProps {
 interface CreateBreakpointFormState {
   fileName: string;
   lineNumber: number;
-  errorMessage: boolean;
+  errorMessage: string;
 }
 
 export class CreateBreakpointForm extends React.Component<
@@ -25,18 +25,18 @@ export class CreateBreakpointForm extends React.Component<
     this.state = {
       fileName: undefined,
       lineNumber: undefined,
-      errorMessage: true
+      errorMessage: undefined
     };
   }
 
   onFileName(fileName) {
     this.setState({ fileName });
-    this.setState({ errorMessage: true });
+    this.setState({ errorMessage: undefined });
   }
 
   onLineNumber(lineNumber) {
     this.setState({ lineNumber });
-    this.setState({ errorMessage: true });
+    this.setState({ errorMessage: undefined });
   }
 
   onCreateBreakpoint() {
@@ -75,7 +75,7 @@ export class CreateBreakpointForm extends React.Component<
   /** Compares the activeBreakpoint list to update the error message in chathead if existed */
   componentDidUpdate(prevProps) {
     if (this.props.activeBreakpoints.length > prevProps.activeBreakpoints.length) {
-      this.setState({ errorMessage: true });
+      this.setState({ errorMessage: undefined });
     }
   }
 
@@ -113,9 +113,9 @@ export class CreateBreakpointForm extends React.Component<
                   e.preventDefault(); // Prevents a page reload from form submit.
                   if (this.checkValidBreakpoint()) {
                     this.onCreateBreakpoint();
-                    this.setState({ errorMessage: true });
+                    this.setState({ errorMessage: undefined });
                   } else {
-                    this.setState({ errorMessage: false });
+                    this.setState({ errorMessage: "ERROR" });
                   }
                 }}
               >
@@ -125,12 +125,12 @@ export class CreateBreakpointForm extends React.Component<
                 onClick={(e) => {
                   e.preventDefault(); // Prevents a page reload from form submit.
                   this.onDeleteAllActiveBreakpoints();
-                  this.setState({ errorMessage: true });
+                  this.setState({ errorMessage: undefined });
                 }}
               >
                 Delete all active breakpoints
               </Button>
-                { !this.state.errorMessage && (
+                { this.state.errorMessage === "ERROR" && (
                 <Card>
                     <CardContent>
                       {

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { TextField, Card, CardContent, Button, Box } from "@material-ui/core";
 import { BreakpointMeta } from "../../common/types/debugger";
-import Alert from '@material-ui/lab/Alert';
-
 
 interface CreateBreakpointFormProps {
   createBreakpoint: (fileName: string, lineNumber: number) => void;
   deleteAllActiveBreakpoints: () => void;
   activeBreakpoints: BreakpointMeta[];
-
 }
 
 interface CreateBreakpointFormState {
@@ -43,10 +40,14 @@ export class CreateBreakpointForm extends React.Component<
   onDeleteAllActiveBreakpoints() {
     this.props.deleteAllActiveBreakpoints();
   }
-  checkValidBreakpoint(){
+
+  checkValidBreakpoint() {
     for (let breakpoint of this.props.activeBreakpoints) {
-      if (breakpoint.location.path == this.state.fileName && breakpoint.location.line == this.state.lineNumber) {
-          return false;
+      if (
+        breakpoint.location.path == this.state.fileName &&
+        breakpoint.location.line == this.state.lineNumber
+      ) {
+        return false;
       }
     }
     return true;
@@ -77,15 +78,24 @@ export class CreateBreakpointForm extends React.Component<
                 onChange={(e) => this.onLineNumber(e.target.value)}
                 variant="outlined"
               />
-              <br/><br/>
-              <Button id='createBpButton' onClick={(e) => {
-                e.preventDefault(); // Prevents a page reload from form submit.
-                if (this.checkValidBreakpoint()){
-                  this.onCreateBreakpoint();
-                } else {
-                  alert("The breakpoint on file: "+ this.state.fileName + " and line number: "+ this.state.lineNumber+ " already exists");
-                };
-                }}>
+              <br />
+              <br />
+              <Button id='createBpButton'
+                onClick={(e) => {
+                  e.preventDefault(); // Prevents a page reload from form submit.
+                  if (this.checkValidBreakpoint()) {
+                    this.onCreateBreakpoint();
+                  } else {
+                    alert(
+                      "The breakpoint on file: " +
+                        this.state.fileName +
+                        " and line number: " +
+                        this.state.lineNumber +
+                        " already exists"
+                    );
+                  }
+                }}
+              >
                 Create Breakpoint
               </Button>
               <Button id='deleteActiveBpButton'

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { TextField, Card, CardContent, Button, Box } from "@material-ui/core";
-import { BreakpointMeta } from "../../common/types/debugger";
+import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
 
 interface CreateBreakpointFormProps {
   createBreakpoint: (fileName: string, lineNumber: number) => void;
   deleteAllActiveBreakpoints: () => void;
   activeBreakpoints: BreakpointMeta[];
+  completedBreakpoints:Breakpoint[];
 }
 
 interface CreateBreakpointFormState {
@@ -50,6 +51,16 @@ export class CreateBreakpointForm extends React.Component<
         return false;
       }
     }
+
+    for (let breakpoint of this.props.completedBreakpoints) {
+      if (
+        breakpoint.location.path == this.state.fileName &&
+        breakpoint.location.line == this.state.lineNumber
+      ) {
+        return false;
+      }
+    }
+
     return true;
   }
 

--- a/app/src/client/chathead/CreateBreakpointForm.tsx
+++ b/app/src/client/chathead/CreateBreakpointForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TextField, Card, CardContent, Button, Box } from "@material-ui/core";
 import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
+import Alert from '@material-ui/lab/Alert';
 
 interface CreateBreakpointFormProps {
   createBreakpoint: (fileName: string, lineNumber: number) => void;
@@ -12,6 +13,7 @@ interface CreateBreakpointFormProps {
 interface CreateBreakpointFormState {
   fileName: string;
   lineNumber: number;
+  errorMessage: boolean;
 }
 
 export class CreateBreakpointForm extends React.Component<
@@ -23,6 +25,7 @@ export class CreateBreakpointForm extends React.Component<
     this.state = {
       fileName: undefined,
       lineNumber: undefined,
+      errorMessage: true
     };
   }
 
@@ -64,6 +67,14 @@ export class CreateBreakpointForm extends React.Component<
     return true;
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.activeBreakpoints.length > prevProps.activeBreakpoints.length) {
+      this.setState({ errorMessage: true });
+    }
+  }
+
+  
+
   render() {
     const { fileName, lineNumber } = this.state;
     return (
@@ -96,14 +107,9 @@ export class CreateBreakpointForm extends React.Component<
                   e.preventDefault(); // Prevents a page reload from form submit.
                   if (this.checkValidBreakpoint()) {
                     this.onCreateBreakpoint();
+                    this.setState({ errorMessage: true });
                   } else {
-                    alert(
-                      "The breakpoint on file: " +
-                        this.state.fileName +
-                        " and line number: " +
-                        this.state.lineNumber +
-                        " already exists"
-                    );
+                    this.setState({ errorMessage: false });
                   }
                 }}
               >
@@ -117,6 +123,21 @@ export class CreateBreakpointForm extends React.Component<
               >
                 Delete all active breakpoints
               </Button>
+                { !this.state.errorMessage && (
+                <Card>
+                    <CardContent>
+                      {
+                          <Alert severity="error">{                      
+                            "The breakpoint on file: " +
+                          this.state.fileName
+                      } <br/> {" and line number: " +
+                          this.state.lineNumber +
+                          " already exists"}</Alert>
+                      }
+                    </CardContent>
+                  </Card>
+                )
+            }
             </form>
           </CardContent>
         </Card>


### PR DESCRIPTION
**Background:**
It allowed user to set multiple breakpoints on the same file and line using marker and manual breakpoint form.

**Work Done:**
This PR prevents user to set multiple breakpoints on same file and line. It also prevents users to set breakpoints on the same line once the breakpoint is hit and have the stack trace for it. It displays error message in the Chathead. 
There are several cases that were needed to take care of while displaying error message. Error cases such as if there is error message displayed already, and user adds new BP through breakpoint marker(different component), the Chathead component will remove the error message displayed in the component by checking requirements.  

**Here is the snippet of how error message is displayed on the UI side when user tries to set multiple breakpoint in same file and same line.**
![Screenshot 2020-07-24 at 12 17 36 PM](https://user-images.githubusercontent.com/59666573/88427519-113fd680-cdc1-11ea-9bac-cff236061cfc.png)


