### PR TITLE
Refactor injected-app bg requests through dependency injection

### DIFF
--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Chathead } from "../chathead/Chathead";
-import * as BackgroundRequest from "../../common/requests/BackgroundRequest";
+import * as backgroundRequest from "../../common/requests/BackgroundRequest";
 import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
 import { BreakpointMarkers } from "../markers/BreakpointMarkers";
 
@@ -15,8 +15,17 @@ interface InjectedAppState {
   localStorage?: Storage
 }
 
-export class InjectedApp extends React.Component<any, InjectedAppState> {
-  constructor(props: InjectedAppState) {
+interface InjectedAppProps {
+  // Explicitly take in a collection of background requests to allow mocking.
+  backgroundRequest?: typeof backgroundRequest;
+}
+
+export class InjectedApp extends React.Component<InjectedAppProps, InjectedAppState> {
+  public static defaultProps = {
+    backgroundRequest: backgroundRequest
+  }
+
+  constructor(props: InjectedAppProps) {
     super(props);
     this.state = {
       projectId: this.getGcpProjectId(),
@@ -70,8 +79,8 @@ export class InjectedApp extends React.Component<any, InjectedAppState> {
    */
   async createBreakPoint(fileName: string, lineNumber: number) {
     // Make the Set breakpoint request in the BackgroundRequest
-    const response = await new BackgroundRequest.SetBreakpointRequest().run(
-      new BackgroundRequest.SetBreakpointRequestData(
+    const response = await new this.props.backgroundRequest.SetBreakpointRequest().run(
+      new this.props.backgroundRequest.SetBreakpointRequestData(
         this.state.debuggeeId,
         fileName,
         lineNumber
@@ -102,8 +111,8 @@ export class InjectedApp extends React.Component<any, InjectedAppState> {
         Object.keys(this.state.activeBreakpoints).length > 0
       ) {
         // Make the list breakpoint request
-        let breakpointListResponse = await new BackgroundRequest.ListBreakPointsRequest().run(
-          new BackgroundRequest.ListBreakpointsData(
+        let breakpointListResponse = await new this.props.backgroundRequest.ListBreakPointsRequest().run(
+          new this.props.backgroundRequest.ListBreakpointsData(
             this.state.debuggeeId,
             waitToken
           )
@@ -133,8 +142,8 @@ export class InjectedApp extends React.Component<any, InjectedAppState> {
   /** Deletes a breakpoint from debugger backend. */
   async deleteBreakpoint(breakpointId: string) {
     // Delete the breakpoint from remote cloud debugger.
-    const deleteBreakpointRequest = await new BackgroundRequest.DeleteBreakpointRequest().run(
-      new BackgroundRequest.DeleteBreakpointRequestData(
+    const deleteBreakpointRequest = await new this.props.backgroundRequest.DeleteBreakpointRequest().run(
+      new this.props.backgroundRequest.DeleteBreakpointRequestData(
         this.state.debuggeeId,
         breakpointId
       )
@@ -155,8 +164,8 @@ export class InjectedApp extends React.Component<any, InjectedAppState> {
     var tempGetBreakpoints = { ...this.state.completedBreakpoints };
     var updatedActiveBPs = { ...this.state.activeBreakpoints };
     for (let breakpointId of breakpointIdsToLoad) {
-      const getBreakpointresponse = await new BackgroundRequest.FetchBreakpointRequest().run(
-        new BackgroundRequest.FetchBreakpointRequestData(
+      const getBreakpointresponse = await new this.props.backgroundRequest.FetchBreakpointRequest().run(
+        new this.props.backgroundRequest.FetchBreakpointRequestData(
           this.state.debuggeeId,
           breakpointId
         )
@@ -176,8 +185,8 @@ export class InjectedApp extends React.Component<any, InjectedAppState> {
   async deleteAllActiveBreakpoints() {
     //delete all active breakpoints from remote cloud debugger.
     for (let breakpointId of Object.values(this.state.activeBreakpoints)) {
-      const deletionRequest = await new BackgroundRequest.DeleteBreakpointRequest().run(
-        new BackgroundRequest.DeleteBreakpointRequestData(
+      const deletionRequest = await new this.props.backgroundRequest.DeleteBreakpointRequest().run(
+        new this.props.backgroundRequest.DeleteBreakpointRequestData(
           this.state.debuggeeId,
           breakpointId.id
         )


### PR DESCRIPTION
**Background**
- Currently many methods in InjectedApp can't be tested, since they call BG Requests
- These requests are imported in, so they can't (easily) be mocked

**Work Done**
- Instead of using the imported BGRequests wrapper, InjectedApp takes this is a prop.
- By default, this prop resolves to the imported version (so no changes needed with other code)
- Now, calling a BG Request should go through the `this.props.backgroundRequest. ...` wrapper
- To mock, InjectedApp can be created with new BGRequest passed in by name, for example:

```
import {FetchProjectsRequestData} from "backgroundRequests" 
<InjectedApp backgroundRequest={{
    FetchProjectsRequest: {
        run: jest.fn()     <---- Mocks the run method so it can be spied on, pass hardcoded return values, etc.
    }
    FetchProjectsRequestData <---- passes the default FetchProjectsRequestData object, if we're not interested in a fake version.
}}/>
```