### PR TITLE
Improved stacktrace presentation

### DIFF
--- a/app/__tests__/chathead/breakpointView.tsx
+++ b/app/__tests__/chathead/breakpointView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { shallow, mount, render, configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { FailedBreakpoint, BreakpointMeta, Breakpoint } from "../../src/common/types/debugger";
-import { getBreakpointErrorMessage, FailedCompletedBreakpointView, CompletedBreakpointView } from "../../src/client/chathead/BreakpointView";
+import { getBreakpointErrorMessage, FailedCompletedBreakpointView, CompletedBreakpointView, StackFrame } from "../../src/client/chathead/BreakpointView";
 import { LocationView, PendingBreakpointView, SuccessfulCompletedBreakpointView, VariablesView} from "../../src/client/chathead/BreakpointView";
 import { AccordionSummary, CircularProgress, Accordion, AccordionDetails } from "@material-ui/core";
 
@@ -103,21 +103,21 @@ describe("SuccessfulCompletedBreakpointView", () => {
     expect(wrapper.find(LocationView).exists()).toBe(true);
   });
 
-  it("shows variables when expanded", () => {
+  it("shows N stackframes", () => {
     const mockBreakpoint: Partial<BreakpointMeta> = {
       location: {
         path: "foo.java",
         line: 24
       },
-      stackFrames: [{locals: []}]
+      stackFrames: [{locals: []}, {locals: []}]
     }
   
     const wrapper = shallow(<SuccessfulCompletedBreakpointView breakpoint={mockBreakpoint}/>);
     expect(
       wrapper.find(AccordionDetails)
              .dive()
-             .find(VariablesView).exists()
-    ).toBe(true);
+             .find(StackFrame).length
+    ).toBe(2);
   });
 });
 

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testPathIgnorePatterns: ["<rootDir>/__integration__"]
+  testPathIgnorePatterns: ["<rootDir>/__integration__"],
+  setupFiles: ["<rootDir>/jest.setup.js"]
 };

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -1,0 +1,5 @@
+import React from "react";
+// Material UI uses this function a lot.
+// It throws errors on server side, which pollutes the Jest logs.
+// solution: https://stackoverflow.com/questions/58070996/how-to-fix-the-warning-uselayouteffect-does-nothing-on-the-server
+React.useLayoutEffect = React.useEffect;

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -61,7 +61,7 @@ export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint
 }
 
 /** A single stackframe (closure context) of variables. */
-const StackFrame = ({stackFrame, breakpoint}) => {
+export const StackFrame = ({stackFrame, breakpoint}) => {
   const {variableTable} = breakpoint;
   return (
     <TreeItem nodeId={stackFrame.function} label={stackFrame.function}>

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -77,6 +77,9 @@ const StackFrame = ({stackFrame, breakpoint}) => {
   );
 }
 
+/** Show data for a single variable in the stacktrace.
+ *  These can be nested to show nested variables in array or object.
+ */
 export const VariableView = ({parentNode, variable, variableTable}) => {
   // Used to not render children until needed.
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -180,21 +183,6 @@ export function getBreakpointErrorMessage(breakpoint: FailedBreakpoint): string{
   // This Regex looks for sequences like $0, $1, ... and replaces them with the parameter for their index.
   const message = format.replace(/\$(\d+)/g, (match, index) => parameters[index]);
   return message;
-}
-
-/** Displays a set of variables from a debugger stack frame. */
-export const VariablesView = ({variables}: {variables: Variable[]}) => {
-  return (
-    <List dense>
-      {
-        variables.map(variable => (
-          <ListItem>
-            <ListItemText primary={variable.name} secondary={variable.value}/>
-          </ListItem>
-        ))
-      }
-    </List>
-  )
 }
 
 /** Displays file name and line number for a breakpoint. */

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -123,7 +123,9 @@ const ChatheadWrapper = styled(Paper)`
   top: 20px;
 
   right: 20px;
-  width: fit-content;
+  width: 600px;
+  max-height: calc(100% - 40px);
+  overflow: auto;
 
   z-index: 1000;
 `;


### PR DESCRIPTION
**Background**
Current breakpoint view uses nested accordions. This takes up a bit too much space, and has limited support for complex data structures.

**Work Done**
Replaces view with a more convention tree-view, and adds support for following complicated data structures.

![image](https://user-images.githubusercontent.com/17712692/88549148-f4d4b180-cfed-11ea-8707-1518d0041009.png)

**Next Steps**
- Some variables have a 'status' flag if they were truncated and not fully returned. Right now this is ignored and shows up as `value = undefined`.
- Should consider how many stackframes we need to show.
- Stackframes can also have arguments, current ignoring these.
- Expressions