### PR TITLE
feat: allow deletion of active bps

### DIFF
--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 
-import { Accordion, AccordionSummary, Typography, List, ListItem, ListItemText, AccordionDetails, CircularProgress, Divider, AccordionActions, Button } from "@material-ui/core";
+import { Accordion, AccordionSummary, Typography, List, ListItem, ListItemText, AccordionDetails, CircularProgress, Divider, AccordionActions, Button, Grid } from "@material-ui/core";
 import { Alert, AlertTitle } from "@material-ui/lab";
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ErrorIcon from '@material-ui/icons/Error';
 import { Variable, Breakpoint, FailedBreakpoint } from "../../common/types/debugger";
 
 /** Used to display a breakpoint that has not yet hit. */
-export const PendingBreakpointView = ({ breakpointMeta }) => {
+export const PendingBreakpointView = ({ breakpointMeta, deleteBreakpoint }) => {
   return (
     <Accordion>
-      <AccordionSummary disabled expandIcon={<CircularProgress/>}>
-        <LocationView breakpoint={breakpointMeta}/>
+      <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
+        <Grid container spacing={3}>
+          <Grid item xs={11}>
+            <LocationView breakpoint={breakpointMeta}/>
+          </Grid>
+          <Grid item xs={1}>
+            <CircularProgress size={20}/>
+          </Grid>
+        </Grid>
       </AccordionSummary>
+      <Divider/>
+      <AccordionActions>
+        <Button size="small" color="secondary" onClick={() => deleteBreakpoint(breakpointMeta.id)}>Delete</Button>
+      </AccordionActions>
     </Accordion>
   );
 };

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -104,7 +104,10 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
         )}
 
         {this.props.activeBreakpoints.map((b) => (
-          <PendingBreakpointView breakpointMeta={b} />
+          <PendingBreakpointView
+            breakpointMeta={b}
+            deleteBreakpoint={this.props.deleteBreakpoint}
+          />
         ))}
 
         {this.props.completedBreakpoints.map((b) => (

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -150,8 +150,10 @@ export class InjectedApp extends React.Component<InjectedAppProps, InjectedAppSt
     );
     // Remove breakpoint from local tracking.
     const updatedCompletedBreakpoints = { ...this.state.completedBreakpoints };
+    const updatedActiveBreakpoints = { ...this.state.activeBreakpoints };
     delete updatedCompletedBreakpoints[breakpointId];
-    this.setState({ completedBreakpoints: updatedCompletedBreakpoints });
+    delete updatedActiveBreakpoints[breakpointId];
+    this.setState({ completedBreakpoints: updatedCompletedBreakpoints, activeBreakpoints: updatedActiveBreakpoints });
   }
 
   /**


### PR DESCRIPTION
NOTE: there's a conflict here but I can deal with it after approval, can't fix online.

**Background**
Because of how the UI was made, active breakpoints cannot be deleted (only completed)

**Work Done**
- Modified breakpointView to allow active breakpoint deletion.
- Modified deletebreakpoint function to also target active.

![image](https://user-images.githubusercontent.com/17712692/88551196-93621200-cff0-11ea-8c9a-6e279c39889d.png)

