### PR TITLE
Add jest setup file to un-pollute test logs

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testPathIgnorePatterns: ["<rootDir>/__integration__"]
+  testPathIgnorePatterns: ["<rootDir>/__integration__"],
+  setupFiles: ["<rootDir>/jest.setup.js"]
 };

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -1,0 +1,5 @@
+import React from "react";
+// Material UI uses this function a lot.
+// It throws errors on server side, which pollutes the Jest logs.
+// solution: https://stackoverflow.com/questions/58070996/how-to-fix-the-warning-uselayouteffect-does-nothing-on-the-server
+React.useLayoutEffect = React.useEffect;


### PR DESCRIPTION
**Background**
Material UI uses some react functionality that throws errors in the Jest log. This doesn't affect tests passing but it makes the logs incredibly hard to use.

**Work Done**
Added a jest setup file that overrides that suspect react method.