### PR TITLE
Add screen-size options for the chathead

### DIFF
--- a/app/__tests__/chathead/appbar.tsx
+++ b/app/__tests__/chathead/appbar.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { shallow, mount, render, configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { Appbar } from "../../src/client/chathead/Appbar";
+
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+
+configure({ adapter: new Adapter() });
+
+describe("Appbar", () => {
+  it("displays title.", () => {
+    const wrapper = shallow(<Appbar title="Foo"/>);
+    expect(wrapper.text()).toBe("Foo");
+  });
+
+  it("displays no back button if no handler provider.", () => {
+    const wrapper = shallow(<Appbar title="Foo"/>);
+    expect(wrapper.find(ArrowBackIcon).length).toBe(0);
+  });
+
+  it("displays back button if handler provided, and responds to click.", () => {
+    const backButtonSpy = jest.fn();
+    const wrapper = shallow(<Appbar title="Foo" onBack={backButtonSpy}/>);
+
+    const backButton = wrapper.find(ArrowBackIcon);
+    expect(backButton.length).toBe(1);
+
+    backButton.parent().simulate("click");
+    expect(backButtonSpy).toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/chathead/appbar.tsx
+++ b/app/__tests__/chathead/appbar.tsx
@@ -4,6 +4,7 @@ import Adapter from "enzyme-adapter-react-16";
 import { Appbar } from "../../src/client/chathead/Appbar";
 
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+import { WindowSizeContext, WindowSize } from "../../src/client/chathead/windowSizeContext";
 
 configure({ adapter: new Adapter() });
 
@@ -28,4 +29,77 @@ describe("Appbar", () => {
     backButton.parent().simulate("click");
     expect(backButtonSpy).toHaveBeenCalled();
   });
+  
+
+  it("shows collapse button and sets correct size.", () => {
+    const setSizeSpy = jest.fn();
+    const wrapper = mount(
+      <WindowSizeContext.Provider value={{size: WindowSize.REGULAR, setSize: setSizeSpy}}>
+        <Appbar/>
+      </WindowSizeContext.Provider>
+    );
+
+    const collapseButton = wrapper.find('#size-collapse');
+    expect(collapseButton.exists()).toBe(true);
+
+    collapseButton.at(0).simulate("click");
+    expect(setSizeSpy).toHaveBeenCalledWith(WindowSize.COLLAPSED);
+  });
+
+  it("shows full screen button and sets correct size", () => {
+    const setSizeSpy = jest.fn();
+    const wrapper = mount(
+      <WindowSizeContext.Provider value={{size: WindowSize.REGULAR, setSize: setSizeSpy}}>
+        <Appbar/>
+      </WindowSizeContext.Provider>
+    );
+
+    const fullscreenButton = wrapper.find('#size-fullscreen');
+    expect(fullscreenButton.exists()).toBe(true);
+
+    fullscreenButton.at(0).simulate("click");
+    expect(setSizeSpy).toHaveBeenCalledWith(WindowSize.FULL_SCREEN);
+  });
+
+  it("shows regular size button and sets correct size", () => {
+    const setSizeSpy = jest.fn();
+    const wrapper = mount(
+      <WindowSizeContext.Provider value={{size: WindowSize.FULL_SCREEN, setSize: setSizeSpy}}>
+        <Appbar/>
+      </WindowSizeContext.Provider>
+    );
+
+    const regularButton = wrapper.find('#size-regular');
+    expect(regularButton.exists()).toBe(true);
+
+    regularButton.at(0).simulate("click");
+    expect(setSizeSpy).toHaveBeenCalledWith(WindowSize.REGULAR);
+  });
+
+  it("doesn't show full screen button in full screen mode.", () => {
+    const setSizeSpy = jest.fn();
+    const wrapper = mount(
+      <WindowSizeContext.Provider value={{size: WindowSize.FULL_SCREEN, setSize: setSizeSpy}}>
+        <Appbar/>
+      </WindowSizeContext.Provider>
+    );
+
+    expect(wrapper.find('#size-fullscreen').exists()).toBe(false);
+  });
+
+  it("doesn't show regular size button in regular mode.", () => {
+    const setSizeSpy = jest.fn();
+    const wrapper = mount(
+      <WindowSizeContext.Provider value={{size: WindowSize.REGULAR, setSize: setSizeSpy}}>
+        <Appbar/>
+      </WindowSizeContext.Provider>
+    );
+
+    expect(wrapper.find('#size-regular').exists()).toBe(false);
+  });
+
+  it("renders custom children", () => {
+    const wrapper = mount(<Appbar><div>foo</div></Appbar>);
+    expect(wrapper.text()).toContain("foo");
+  })
 });

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactChildren } from "react";
 
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
@@ -7,8 +7,17 @@ import PhotoSizeSelectSmallIcon from '@material-ui/icons/PhotoSizeSelectSmall';
 import { Toolbar, Typography, IconButton, AppBar, Box } from "@material-ui/core";
 import { WindowSizeContext, WindowSize } from "./windowSizeContext";
 
+interface AppBarProps {
+  /** Displayed text for the appbar */
+  title: string;
+  /** An optional function to handle 'go back' action. If defined, a back button will be shown. */
+  onBack: () => void;
+  /** Optional nodes to add between title and resize buttons. */
+  children: ReactChildren;
+}
+
 /** A unified header for all pages within the chathead. */
-export const Appbar = ({title, onBack, children = null}) => (
+export const Appbar = ({title, onBack, children = null}: AppBarProps) => (
   <AppBar position="static">
     <Toolbar>
       {

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import RefreshIcon from '@material-ui/icons/Refresh';
 import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
 import SettingsOverscanIcon from '@material-ui/icons/SettingsOverscan';
 import PhotoSizeSelectSmallIcon from '@material-ui/icons/PhotoSizeSelectSmall';
@@ -8,17 +7,12 @@ import { Toolbar, Typography, IconButton, AppBar, Box } from "@material-ui/core"
 import { WindowSizeContext, WindowSize } from "./windowSizeContext";
 
 /** A unified header for all pages within the chathead. */
-export const Appbar = ({title, onRefresh}) => (
+export const Appbar = ({title, children = null}) => (
   <AppBar position="static">
     <Toolbar>
       <Typography variant="h6">{title}</Typography>
       <Box flexGrow={1}/>
-      {onRefresh && (
-          <IconButton color="inherit" onClick={onRefresh}>
-            <RefreshIcon/>
-          </IconButton>
-        )
-      }
+      {children}
       <WindowSizeContext.Consumer>
         {({size, setSize}) => (
           <>

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -13,7 +13,7 @@ interface AppBarProps {
   /** An optional function to handle 'go back' action. If defined, a back button will be shown. */
   onBack: () => void;
   /** Optional nodes to add between title and resize buttons. */
-  children: ReactChildren;
+  children?: ReactChildren;
 }
 
 /** A unified header for all pages within the chathead. */

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import RefreshIcon from '@material-ui/icons/Refresh';
+import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
+import SettingsOverscanIcon from '@material-ui/icons/SettingsOverscan';
+import PhotoSizeSelectSmallIcon from '@material-ui/icons/PhotoSizeSelectSmall';
+import { Toolbar, Typography, IconButton, AppBar, Box } from "@material-ui/core";
+import { WindowSizeContext, WindowSize } from "./windowSizeContext";
+
+/** A unified header for all pages within the chathead. */
+export const Appbar = ({title, onRefresh}) => (
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="h6">{title}</Typography>
+      <Box flexGrow={1}/>
+      {onRefresh && (
+          <IconButton color="inherit" onClick={onRefresh}>
+            <RefreshIcon/>
+          </IconButton>
+        )
+      }
+      <WindowSizeContext.Consumer>
+        {({size, setSize}) => (
+          <>
+            <IconButton color="inherit" onClick={() => setSize(WindowSize.COLLAPSED)}>
+              <PhotoSizeSelectSmallIcon/>
+            </IconButton>
+            {
+              size !== WindowSize.FULL_SCREEN ?
+                <IconButton color="inherit" onClick={() => setSize(WindowSize.FULL_SCREEN)}>
+                  <SettingsOverscanIcon/>
+                </IconButton>
+                :
+                <IconButton color="inherit" onClick={() => setSize(WindowSize.REGULAR)}>
+                  <PictureInPictureIcon/>
+              </IconButton>
+            }
+          </>
+        )}
+      </WindowSizeContext.Consumer>
+    </Toolbar>
+  </AppBar>
+)

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
 import SettingsOverscanIcon from '@material-ui/icons/SettingsOverscan';
 import PhotoSizeSelectSmallIcon from '@material-ui/icons/PhotoSizeSelectSmall';
@@ -7,9 +8,16 @@ import { Toolbar, Typography, IconButton, AppBar, Box } from "@material-ui/core"
 import { WindowSizeContext, WindowSize } from "./windowSizeContext";
 
 /** A unified header for all pages within the chathead. */
-export const Appbar = ({title, children = null}) => (
+export const Appbar = ({title, onBack, children = null}) => (
   <AppBar position="static">
     <Toolbar>
+      {
+        onBack && (
+          <IconButton edge="start" color="inherit" onClick={onBack}>
+            <ArrowBackIcon/>
+          </IconButton>
+        )
+      }
       <Typography variant="h6">{title}</Typography>
       <Box flexGrow={1}/>
       {children}

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -11,7 +11,7 @@ interface AppBarProps {
   /** Displayed text for the appbar */
   title: string;
   /** An optional function to handle 'go back' action. If defined, a back button will be shown. */
-  onBack: () => void;
+  onBack?: () => void;
   /** Optional nodes to add between title and resize buttons. */
   children?: ReactChildren;
 }

--- a/app/src/client/chathead/Appbar.tsx
+++ b/app/src/client/chathead/Appbar.tsx
@@ -33,16 +33,16 @@ export const Appbar = ({title, onBack, children = null}: AppBarProps) => (
       <WindowSizeContext.Consumer>
         {({size, setSize}) => (
           <>
-            <IconButton color="inherit" onClick={() => setSize(WindowSize.COLLAPSED)}>
+            <IconButton id="size-collapse" color="inherit" onClick={() => setSize(WindowSize.COLLAPSED)}>
               <PhotoSizeSelectSmallIcon/>
             </IconButton>
             {
               size !== WindowSize.FULL_SCREEN ?
-                <IconButton color="inherit" onClick={() => setSize(WindowSize.FULL_SCREEN)}>
+                <IconButton id="size-fullscreen" color="inherit" onClick={() => setSize(WindowSize.FULL_SCREEN)}>
                   <SettingsOverscanIcon/>
                 </IconButton>
                 :
-                <IconButton color="inherit" onClick={() => setSize(WindowSize.REGULAR)}>
+                <IconButton id="size-regular" color="inherit" onClick={() => setSize(WindowSize.REGULAR)}>
                   <PictureInPictureIcon/>
               </IconButton>
             }

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -145,7 +145,7 @@ const ChatheadWrapper = styled(Paper)`
 
   right: 20px;
   width: 600px;
-  min-height: 60px;
+  min-height: 300px;
   max-height: calc(100% - 40px);
   overflow: auto;
 
@@ -155,13 +155,13 @@ const ChatheadWrapper = styled(Paper)`
 
   ${props => props.minimized && css`
     width: 60px;
-    max-height: 60px;
+    min-height: 60px;
     border-radius: 30px !important;
   `}
 
   ${props => props.maximized && css`
     width: calc(100% - 40px);
-    height: calc(100% - 40px);
+    min-height: calc(100% - 40px);
     top: 20px;
     right: 20px;
   `}

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, {css} from "styled-components";
 import { SelectProjectContainer } from "./SelectProject";
 import { SelectDebuggeeContainer } from "./SelectDebuggee";
 import { CreateBreakpointForm } from "./CreateBreakpointForm";
@@ -40,18 +40,34 @@ interface ChatheadProps {
   deleteAllActiveBreakpoints: () => void;
 }
 
-interface ChatheadState {}
+interface ChatheadState {
+  minimized: boolean;
+  maximized: boolean;
+}
 
 export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
   constructor(props: ChatheadProps) {
     super(props);
+    this.state = {
+      minimized: false
+    }
+  }
+
+  toggleMinimized() {
+    this.setState({minimized: !this.state.minimized, maximized: false});
+  }
+
+  toggleMaximized() {
+    this.setState({maximized: !this.state.maximized});
   }
 
   render() {
-    const { projectId, debuggeeId, projectDescription } = this.props;
+    const { projectId, debuggeeId } = this.props;
+    const { minimized, maximized} = this.state;
     return (
-      <ChatheadWrapper>
-        {!projectId && (
+      <ChatheadWrapper minimized={minimized} maximized={maximized} onClick={() => minimized && this.toggleMinimized()}>
+        {minimized && <CloudLogo src="https://pbs.twimg.com/profile_images/1105378972156649472/9W16lxHj_400x400.png"/>}
+        {!minimized && !projectId && (
           <SelectProjectContainer
             projectId={this.props.projectId}
             projectDescription={this.props.projectDescription}
@@ -62,10 +78,12 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
               );
               return response.projects;
             }}
+            toggleMinimized={() => this.toggleMinimized()}
+            toggleMaximized={() => this.toggleMaximized()}
           />
         )}
 
-        {projectId && !debuggeeId && (
+        {!minimized && projectId && !debuggeeId && (
           <SelectDebuggeeContainer
             projectId={this.props.projectId}
             debuggeeId={this.props.debuggeeId}
@@ -83,7 +101,7 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
           />
         )}
 
-        {projectId && debuggeeId && (
+        {!minimized && projectId && debuggeeId && (
           <>
             <AppBar position="static">
               <Toolbar>
@@ -106,14 +124,11 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
           </>
         }
 
-        {this.props.activeBreakpoints.map((b) => (
-          <PendingBreakpointView
-            breakpointMeta={b}
-            deleteBreakpoint={this.props.deleteBreakpoint}
-          />
+        {!minimized && this.props.activeBreakpoints.map((b) => (
+          <PendingBreakpointView breakpointMeta={b} deleteBreakpoint={this.props.deleteBreakpoint}/>
         ))}
 
-        {this.props.completedBreakpoints.map((b) => (
+        {!minimized && this.props.completedBreakpoints.map((b) => (
           <CompletedBreakpointView
             breakpoint={b}
             deleteBreakpoint={this.props.deleteBreakpoint}
@@ -130,8 +145,30 @@ const ChatheadWrapper = styled(Paper)`
 
   right: 20px;
   width: 600px;
+  min-height: 60px;
   max-height: calc(100% - 40px);
   overflow: auto;
 
   z-index: 1000;
+
+  transition: all 0.4s !important;
+
+  ${props => props.minimized && css`
+    width: 60px;
+    max-height: 60px;
+    border-radius: 30px !important;
+  `}
+
+  ${props => props.maximized && css`
+    width: calc(100% - 40px);
+    height: calc(100% - 40px);
+    top: 20px;
+    right: 20px;
+  `}
+`;
+
+const CloudLogo = styled.img`
+  height: 50px;
+  margin-top: 5px;
+  margin-left: 5px;
 `;

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -20,6 +20,7 @@ import Paper from "@material-ui/core/Paper";
 import { AppBar, Toolbar, Typography, IconButton } from "@material-ui/core";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import { WindowSize, WindowSizeContext } from "./windowSizeContext";
+import { Appbar } from "./Appbar";
 // Jest has trouble with this, so only import in actual builds.
 if (process.env.NODE_ENV !== "test") {
   import("fontsource-roboto");
@@ -98,18 +99,7 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
 
               {projectId && debuggeeId && (
                 <>
-                  <AppBar position="static">
-                    <Toolbar>
-                      <IconButton
-                        edge="start"
-                        color="inherit"
-                        onClick={() => this.props.setDebuggee(undefined)}
-                      >
-                        <ArrowBackIcon />
-                      </IconButton>
-                      <Typography variant="h6">Breakpoints</Typography>
-                    </Toolbar>
-                  </AppBar>
+                  <Appbar title="Breakpoints" onBack={() => this.props.setDebuggee(undefined)}/>
                   <CreateBreakpointForm
                     activeBreakpoints={this.props.activeBreakpoints}
                     completedBreakpoints={this.props.completedBreakpoints}

--- a/app/src/client/chathead/Chathead.tsx
+++ b/app/src/client/chathead/Chathead.tsx
@@ -74,8 +74,6 @@ export class Chathead extends React.Component<ChatheadProps, ChatheadState> {
                     );
                     return response.projects;
                   }}
-                  toggleMinimized={() => this.toggleMinimized()}
-                  toggleMaximized={() => this.toggleMaximized()}
                 />
               )}
 

--- a/app/src/client/chathead/SelectDebuggee.tsx
+++ b/app/src/client/chathead/SelectDebuggee.tsx
@@ -3,10 +3,10 @@ import { SelectView } from "./GeneralSelectView";
 import { Debuggee } from "../../common/types/debugger";
 
 import { Toolbar, Typography, AppBar, Card, CardContent, Box, IconButton } from "@material-ui/core";
-import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import Alert from '@material-ui/lab/Alert';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import { BackgroundRequestError } from "../../common/requests/BackgroundRequest";
+import { Appbar } from "./Appbar";
 
 interface SelectDebuggeeContainerProps {
   projectId: string;
@@ -59,20 +59,14 @@ export class SelectDebuggeeContainer extends React.Component<
   render() {
     return (
       <>
-        <AppBar position="static">
-          <Toolbar>
-            <IconButton edge="start" color="inherit" onClick={this.props.backToProjects}>
-              <ArrowBackIcon/>
-            </IconButton>
-            <Typography variant="h6">{this.props.projectId}</Typography>
-            {!this.state.debuggeesLoading && (
-                <IconButton color="inherit" onClick={() => this.loadDebuggees()}>
-                  <RefreshIcon/>
-                </IconButton>
-              )
-            }
-          </Toolbar>
-        </AppBar>
+        <Appbar title={this.props.projectId} onBack={this.props.backToProjects}>
+          {!this.state.debuggeesLoading && (
+              <IconButton color="inherit" onClick={() => this.loadDebuggees()}>
+                <RefreshIcon/>
+              </IconButton>
+            )
+          }
+        </Appbar>
         <Box m={1}>
           <Card>
             <CardContent>

--- a/app/src/client/chathead/SelectProject.tsx
+++ b/app/src/client/chathead/SelectProject.tsx
@@ -4,8 +4,8 @@ import { Project } from "../../common/types/debugger";
 import { AppBar, Toolbar, Typography, Card, CardContent, Box, IconButton } from "@material-ui/core";
 import Alert from '@material-ui/lab/Alert';
 import RefreshIcon from '@material-ui/icons/Refresh';
-import MinimizeIcon from "@material-ui/icons/Minimize";
-import MaximizeIcon from "@material-ui/icons/Maximize";
+import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
+import SettingsOverscanIcon from '@material-ui/icons/SettingsOverscan';
 import { BackgroundRequestError } from "../../common/requests/BackgroundRequest";
 
 interface SelectProjectContainerProps {
@@ -69,10 +69,10 @@ export class SelectProjectContainer extends React.Component<
               )
             }
             <IconButton color="inherit" onClick={() => this.props.toggleMinimized()}>
-              <MinimizeIcon/>
+              <PictureInPictureIcon/>
             </IconButton>
             <IconButton color="inherit" onClick={() => this.props.toggleMaximized()}>
-              <MaximizeIcon/>
+              <SettingsOverscanIcon/>
             </IconButton>
           </Toolbar>
         </AppBar>

--- a/app/src/client/chathead/SelectProject.tsx
+++ b/app/src/client/chathead/SelectProject.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { SelectView } from "./GeneralSelectView";
 import { Project } from "../../common/types/debugger";
-import { AppBar, Toolbar, Typography, Card, CardContent, Box, IconButton } from "@material-ui/core";
+import { Toolbar, Typography, Card, CardContent, Box, IconButton } from "@material-ui/core";
 import Alert from '@material-ui/lab/Alert';
-import RefreshIcon from '@material-ui/icons/Refresh';
-import PictureInPictureIcon from '@material-ui/icons/PictureInPicture';
-import SettingsOverscanIcon from '@material-ui/icons/SettingsOverscan';
+
 import { BackgroundRequestError } from "../../common/requests/BackgroundRequest";
+import { Appbar } from "./Appbar";
 
 interface SelectProjectContainerProps {
   projectId?: string;
@@ -59,23 +58,10 @@ export class SelectProjectContainer extends React.Component<
   render() {
     return (
       <>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6">Select Project</Typography>
-            {!this.state.projectsLoading && (
-                <IconButton color="inherit" onClick={() => this.loadProjects()}>
-                  <RefreshIcon/>
-                </IconButton>
-              )
-            }
-            <IconButton color="inherit" onClick={() => this.props.toggleMinimized()}>
-              <PictureInPictureIcon/>
-            </IconButton>
-            <IconButton color="inherit" onClick={() => this.props.toggleMaximized()}>
-              <SettingsOverscanIcon/>
-            </IconButton>
-          </Toolbar>
-        </AppBar>
+        <Appbar
+          title="Select Project"
+          onRefresh={!this.state.projectsLoading && (() => this.loadProjects())}d
+        />
         <Box m={1}>
           <Card>
             <CardContent>

--- a/app/src/client/chathead/SelectProject.tsx
+++ b/app/src/client/chathead/SelectProject.tsx
@@ -4,6 +4,7 @@ import { Project } from "../../common/types/debugger";
 import { Toolbar, Typography, Card, CardContent, Box, IconButton } from "@material-ui/core";
 import Alert from '@material-ui/lab/Alert';
 
+import RefreshIcon from '@material-ui/icons/Refresh';
 import { BackgroundRequestError } from "../../common/requests/BackgroundRequest";
 import { Appbar } from "./Appbar";
 
@@ -58,10 +59,13 @@ export class SelectProjectContainer extends React.Component<
   render() {
     return (
       <>
-        <Appbar
-          title="Select Project"
-          onRefresh={!this.state.projectsLoading && (() => this.loadProjects())}d
-        />
+        <Appbar title="Select Project">
+          {!this.state.projectsLoading && (
+            <IconButton color="inherit" onClick={() => this.loadProjects()}>
+              <RefreshIcon/>
+            </IconButton>
+          )} 
+        </Appbar>
         <Box m={1}>
           <Card>
             <CardContent>

--- a/app/src/client/chathead/SelectProject.tsx
+++ b/app/src/client/chathead/SelectProject.tsx
@@ -4,12 +4,16 @@ import { Project } from "../../common/types/debugger";
 import { AppBar, Toolbar, Typography, Card, CardContent, Box, IconButton } from "@material-ui/core";
 import Alert from '@material-ui/lab/Alert';
 import RefreshIcon from '@material-ui/icons/Refresh';
+import MinimizeIcon from "@material-ui/icons/Minimize";
+import MaximizeIcon from "@material-ui/icons/Maximize";
 import { BackgroundRequestError } from "../../common/requests/BackgroundRequest";
 
 interface SelectProjectContainerProps {
   projectId?: string;
   loadProjects: () => Promise<Project[]>;
   onChange: (projectId) => void;
+  toggleMinimized: () => void;
+  toggleMaximized: () => void;
 }
 
 interface SelectProjectContainerState {
@@ -64,6 +68,12 @@ export class SelectProjectContainer extends React.Component<
                 </IconButton>
               )
             }
+            <IconButton color="inherit" onClick={() => this.props.toggleMinimized()}>
+              <MinimizeIcon/>
+            </IconButton>
+            <IconButton color="inherit" onClick={() => this.props.toggleMaximized()}>
+              <MaximizeIcon/>
+            </IconButton>
           </Toolbar>
         </AppBar>
         <Box m={1}>

--- a/app/src/client/chathead/windowSizeContext.tsx
+++ b/app/src/client/chathead/windowSizeContext.tsx
@@ -7,4 +7,4 @@ export enum WindowSize {
   FULL_SCREEN // Full screened
 }
 
-export const WindowSizeContext = React.createContext<{size: WindowSize, setSize: (size: WindowSize) => void}>(undefined);
+export const WindowSizeContext = React.createContext<{size: WindowSize, setSize: (size: WindowSize) => void}>({size: undefined, setSize: () => {}});

--- a/app/src/client/chathead/windowSizeContext.tsx
+++ b/app/src/client/chathead/windowSizeContext.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+/** Possible sizes for the chathead. */
+export enum WindowSize {
+  COLLAPSED, // Collapsed into a bubble
+  REGULAR, // The usual view, a rectangle in top right.
+  FULL_SCREEN // Full screened
+}
+
+export const WindowSizeContext = React.createContext<{size: WindowSize, setSize: (size: WindowSize) => void}>(undefined);


### PR DESCRIPTION
**Background**
- Sometimes the chathead appears too big (when just trying to look at code for example)
- Other times it seems too small (trying to review a stacktrace)

**Work Done**
- Added buttons to toggle between three view modes, collapsed (circle), regular, and full-screen.
- Refactored the appbar into a common class.

![image](https://user-images.githubusercontent.com/17712692/88681815-f8d10400-d0bf-11ea-9917-56feecfa96f9.png)
![image](https://user-images.githubusercontent.com/17712692/88681843-fff81200-d0bf-11ea-8801-09f5de9ae0ac.png)
