### PR TITLE
Add automatic reauthentication once user has given initial consent

### DIFF
--- a/app/src/background/background.ts
+++ b/app/src/background/background.ts
@@ -3,4 +3,10 @@ import * as backgroundRequestHandler from "./backgroundRequestHandler";
 
 window.onload = (event) => {
   backgroundRequestHandler.BackgroundRequestHandler.listen();
+
+  // The first time we authenticate, we want it to be manual (for good UX.)
+  // However, after that, it's okay to automatically. authenticate.
+  if (extensionAuthHandler.hasUserAuthConsent()) {
+    extensionAuthHandler.startPollingAuth();
+  }
 };

--- a/app/src/background/backgroundRequestHandler.ts
+++ b/app/src/background/backgroundRequestHandler.ts
@@ -203,10 +203,9 @@ BackgroundRequestHandler.on<backgroundRequest.GetAuthStateRequestData>(
 BackgroundRequestHandler.on<backgroundRequest.AuthenticationRequestData>(
   backgroundRequest.BackgroundRequestType.AUTHENTICATION,
   async () => {
-    await extensionAuthHandler.getToken();
-    setInterval(() => {
-      extensionAuthHandler.getToken();
-    }, 5 * 60 * 1000);
+    // Start ongoing authentication, and wait for the first auth to complete.
+    await extensionAuthHandler.startPollingAuth();
+    extensionAuthHandler.setUserAuthConsent(true);
     return {};
   }
 );

--- a/app/src/background/extensionAuthHandler.ts
+++ b/app/src/background/extensionAuthHandler.ts
@@ -25,3 +25,27 @@ export function getToken() {
 export function setAuthToken(access_token) {
   api.setAuthToken(access_token);
 }
+
+/** After being called, this will authenticate once (initially), and every 5 minutes. */
+export async function startPollingAuth() {
+  // Set interval doesn't call at time 0, so must manually do this.
+  await getToken();
+  setInterval(() => {
+    getToken();
+  }, 5 * 60 * 1000);
+}
+
+/** Use this to set the user's auth consent. If they manually sign in once,
+ * we'll assume we have permission to automatically sign in going forward.
+ */
+export function setUserAuthConsent(hasConsent: boolean) {
+  // This manual string cast is needed for local storage.
+  localStorage.setItem("auth-consent", hasConsent ? "true" : "false");
+}
+
+/** If true, this means the user has consented to auth in the past,
+ * and we can sign in automatically.
+ */
+export function hasUserAuthConsent() {
+  return localStorage.getItem("auth-consent") === "true";
+}


### PR DESCRIPTION
**Background**
Whenever the background script restarts (which will happen if user uses this multiple times), they had to reauthenticate.
I think it's a fair assumption that if a user gives authentication consent once, they intend to stay signed in (given it's an extension)

**Work Done**
Added mechanism where signing in sets a 'consent' flag in localStorage. After first signin, extension will automatically authenticate with this.