### PR TITLE
Add expression support in stacktrace

### DIFF
--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -46,7 +46,7 @@ export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: Comple
 
 /** Shows stackframe data for a successful breakpoint. */
 export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: CompletedBreakpointViewProps) => {
-  const {stackFrames} = breakpoint;
+  const {stackFrames, evaluatedExpressions, variableTable} = breakpoint;
   console.log(breakpoint);
   return (
     <Accordion defaultExpanded>
@@ -59,8 +59,17 @@ export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint
           defaultExpandIcon={<ChevronRightIcon />}
         >
           {
-            stackFrames.map(stackFrame => <StackFrame stackFrame={stackFrame} breakpoint={breakpoint}/>)
+            evaluatedExpressions && (
+              <TreeItem nodeId="expressions" label="Expressions">
+                {evaluatedExpressions.map(expression => <VariableView variable={expression} parentNode={"expressions"} variableTable={variableTable}/>)}
+              </TreeItem>
+            )
           }
+          <TreeItem nodeId="stackframes" label="Stackframes">
+            {
+              stackFrames.map(stackFrame => <StackFrame stackFrame={stackFrame} breakpoint={breakpoint}/>)
+            }
+          </TreeItem>
         </TreeView>
       </AccordionDetails>
       <Divider/>
@@ -149,9 +158,12 @@ export const VariableLabel = ({name, type, value}) => (
     <Box fontWeight="fontWeightMedium" display="inline">
       {name}
     </Box>
-    <Box fontWeight="fontWeightRegular" display="inline">
-      {` (${type})`}
-    </Box>
+    {type && (
+      <Box fontWeight="fontWeightRegular" display="inline">
+        {` (${type})`}
+      </Box>
+    )}
+
     {
       value && (
         <Box fontWeight="fontWeightRegular" display="inline">

--- a/app/src/client/injected/injected-app.tsx
+++ b/app/src/client/injected/injected-app.tsx
@@ -220,8 +220,8 @@ export class InjectedApp extends React.Component<InjectedAppProps, InjectedAppSt
             this.setState({ projectId });
           }}
           setDebuggee={(debuggeeId) => this.setState({ debuggeeId })}
-          createBreakpoint={(fileName, lineNumber) =>
-            this.createBreakPoint(fileName, lineNumber)
+          createBreakpoint={(fileName, lineNumber, condition, expressions) =>
+            this.createBreakPoint(fileName, lineNumber, condition, expressions)
           }
           deleteBreakpoint={(breakpointId: string) =>
             this.deleteBreakpoint(breakpointId)


### PR DESCRIPTION
**Background**
While you can currently set conditions and expressions, we don't show expressions anywhere in the returned stacktrace UI.

**Work Done**
Added a dedicated UI for expressions in the stacktrace.

![image](https://user-images.githubusercontent.com/17712692/89057628-fd99f000-d32b-11ea-9a5f-f119884e6019.png)
