### PR TITLE
Add stacktrace data to breakpoint marker popover

### DIFF
--- a/app/__tests__/chathead/breakpointView.tsx
+++ b/app/__tests__/chathead/breakpointView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { shallow, mount, render, configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { FailedBreakpoint, BreakpointMeta, Breakpoint } from "../../src/common/types/debugger";
-import { getBreakpointErrorMessage, FailedCompletedBreakpointView, CompletedBreakpointView, StackFrame } from "../../src/client/chathead/BreakpointView";
+import { getBreakpointErrorMessage, FailedCompletedBreakpointView, CompletedBreakpointView, StackFrame, SuccessfulCompletedBreakpointData, FailedCompletedBreakpointData } from "../../src/client/chathead/BreakpointView";
 import { LocationView, PendingBreakpointView, SuccessfulCompletedBreakpointView, VariablesView} from "../../src/client/chathead/BreakpointView";
 import { AccordionSummary, CircularProgress, Accordion, AccordionDetails } from "@material-ui/core";
 
@@ -103,7 +103,7 @@ describe("SuccessfulCompletedBreakpointView", () => {
     expect(wrapper.find(LocationView).exists()).toBe(true);
   });
 
-  it("shows N stackframes", () => {
+  it("shows BP data", () => {
     const mockBreakpoint: Partial<BreakpointMeta> = {
       location: {
         path: "foo.java",
@@ -116,10 +116,27 @@ describe("SuccessfulCompletedBreakpointView", () => {
     expect(
       wrapper.find(AccordionDetails)
              .dive()
-             .find(StackFrame).length
-    ).toBe(2);
+             .find(SuccessfulCompletedBreakpointData).exists()
+    ).toBe(true)
   });
 });
+
+describe("SuccessfulCompletedBreakpointData", () => {
+  it("shows N stackframes", () => {
+    const mockBreakpoint: Partial<BreakpointMeta> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      stackFrames: [{locals: []}, {locals: []}]
+    }
+  
+    const wrapper = shallow(<SuccessfulCompletedBreakpointData breakpoint={mockBreakpoint}/>);
+    expect(
+      wrapper.find(StackFrame).length
+    ).toBe(2);
+  });
+})
 
 describe("FailedCompletedBreakpointView", () => {
   it("is accordion", () => {
@@ -160,7 +177,7 @@ describe("FailedCompletedBreakpointView", () => {
     expect(wrapper.find(LocationView).exists()).toBe(true);
   });
 
-  it("shows error message", () => {
+  it("shows error data", () => {
     const mockBreakpoint: Partial<FailedBreakpoint> = {
       location: {
         path: "foo.java",
@@ -176,6 +193,27 @@ describe("FailedCompletedBreakpointView", () => {
     }
   
     const wrapper = shallow(<FailedCompletedBreakpointView breakpoint={mockBreakpoint}/>);
+    expect(wrapper.find(FailedCompletedBreakpointData).exists()).toBe(true);
+  });
+});
+
+describe("FailedCompletedBreakpointData", () => {
+  it("shows error message", () => {
+    const mockBreakpoint: Partial<FailedBreakpoint> = {
+      location: {
+        path: "foo.java",
+        line: 24
+      },
+      status: {
+        isError: true,
+        description: {
+          format: "Hello $0 and $1.",
+          parameters: ["foo", "bar"]
+        }
+      }
+    }
+  
+    const wrapper = shallow(<FailedCompletedBreakpointData breakpoint={mockBreakpoint}/>);
     expect(wrapper.html()).toContain("MuiAlert-standardError");
     expect(wrapper.text()).toContain("Hello foo and bar.");
   });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6320,8 +6320,7 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -17487,6 +17486,27 @@
       "integrity": "sha512-dXU9Hj7l0OvmG5s39gwmBuZdYvf5kn17tMMPYg5Hpu4vgnSdfoGkE8kt5J449BWmZZaLMTf5pExcz80Du9dwog==",
       "requires": {
         "prop-types": "^15.5.8"
+      }
+    },
+    "material-ui-popup-state": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-1.6.1.tgz",
+      "integrity": "sha512-I1Cu8hc3RPPTZ7p946q6qQB+n68JuhoiOxclV+wft8bplYGHFLjbNmF59wQMTN6oRZD42QuVtTxDv7LIi0eB8w==",
+      "requires": {
+        "@babel/runtime": "^7.1.5",
+        "@material-ui/types": "^4.1.1",
+        "classnames": "^2.2.6",
+        "prop-types": "^15.0.0"
+      },
+      "dependencies": {
+        "@material-ui/types": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+          "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+          "requires": {
+            "@types/react": "*"
+          }
+        }
       }
     },
     "md5.js": {

--- a/app/package.json
+++ b/app/package.json
@@ -59,6 +59,7 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "fontsource-roboto": "^2.1.4",
     "material-ui-image": "^3.2.3",
+    "material-ui-popup-state": "^1.6.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-google-button": "^0.7.1",

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -46,7 +46,6 @@ export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: Comple
 
 /** Shows stackframe data for a successful breakpoint. */
 export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: CompletedBreakpointViewProps) => {
-  const {stackFrames, evaluatedExpressions, variableTable} = breakpoint;
   console.log(breakpoint);
   return (
     <Accordion defaultExpanded>
@@ -54,23 +53,7 @@ export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint
         <LocationView breakpoint={breakpoint}/>
       </AccordionSummary>
       <AccordionDetails>
-        <TreeView
-          defaultCollapseIcon={<ExpandMoreIcon />}
-          defaultExpandIcon={<ChevronRightIcon />}
-        >
-          {
-            evaluatedExpressions && (
-              <TreeItem nodeId="expressions" label="Expressions">
-                {evaluatedExpressions.map(expression => <VariableView variable={expression} parentNode={"expressions"} variableTable={variableTable}/>)}
-              </TreeItem>
-            )
-          }
-          <TreeItem nodeId="stackframes" label="Stackframes">
-            {
-              stackFrames.map(stackFrame => <StackFrame stackFrame={stackFrame} breakpoint={breakpoint}/>)
-            }
-          </TreeItem>
-        </TreeView>
+        <SuccessfulCompletedBreakpointData breakpoint={breakpoint}/>
       </AccordionDetails>
       <Divider/>
       <AccordionActions>
@@ -78,6 +61,30 @@ export const SuccessfulCompletedBreakpointView = ({ breakpoint, deleteBreakpoint
       </AccordionActions>
     </Accordion>
   );
+}
+
+/** Stacktrace and expression data for a successful breakpoint. */
+export const SuccessfulCompletedBreakpointData = ({breakpoint}) => {
+  const {stackFrames, evaluatedExpressions, variableTable} = breakpoint;
+  return (
+    <TreeView
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+    >
+      {
+        evaluatedExpressions && (
+          <TreeItem nodeId="expressions" label="Expressions">
+            {evaluatedExpressions.map(expression => <VariableView variable={expression} parentNode={"expressions"} variableTable={variableTable}/>)}
+          </TreeItem>
+        )
+      }
+      <TreeItem nodeId="stackframes" label="Stackframes">
+        {
+          stackFrames.map(stackFrame => <StackFrame stackFrame={stackFrame} breakpoint={breakpoint}/>)
+        }
+      </TreeItem>
+    </TreeView>
+  )
 }
 
 /** A single stackframe (closure context) of variables. */

--- a/app/src/client/chathead/BreakpointView.tsx
+++ b/app/src/client/chathead/BreakpointView.tsx
@@ -37,8 +37,7 @@ interface CompletedBreakpointViewProps {
   
 /** Used to display data for a breakpoint that has already hit. */
 export const CompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: CompletedBreakpointViewProps) => {
-  const {status} = breakpoint;
-  if (status && status.isError) {
+  if (!breakpointIsSuccessful(breakpoint)) {
     return <FailedCompletedBreakpointView breakpoint={breakpoint} deleteBreakpoint={deleteBreakpoint}/>;
   }
   return <SuccessfulCompletedBreakpointView breakpoint={breakpoint} deleteBreakpoint={deleteBreakpoint}/>;
@@ -85,6 +84,17 @@ export const SuccessfulCompletedBreakpointData = ({breakpoint}) => {
       </TreeItem>
     </TreeView>
   )
+}
+
+/** Error data for failed breakpoint. */
+export const FailedCompletedBreakpointData = ({breakpoint}) => {
+  return (
+    <Alert severity="error">
+      {/* Currently this title causes issues with the width of the chathead */}
+      {/* <AlertTitle>{status.refersTo}</AlertTitle> */}
+      {getBreakpointErrorMessage(breakpoint)}
+    </Alert>
+  );
 }
 
 /** A single stackframe (closure context) of variables. */
@@ -189,11 +199,7 @@ export const FailedCompletedBreakpointView = ({ breakpoint, deleteBreakpoint }: 
         <LocationView breakpoint={breakpoint}/>
       </AccordionSummary>
       <AccordionDetails>
-        <Alert severity="error">
-          {/* Currently this title causes issues with the width of the chathead */}
-          {/* <AlertTitle>{status.refersTo}</AlertTitle> */}
-          {getBreakpointErrorMessage(breakpoint)}
-        </Alert>
+        <FailedCompletedBreakpointData breakpoint={breakpoint}/>
       </AccordionDetails>
       <Divider/>
       <AccordionActions>
@@ -221,4 +227,10 @@ export const LocationView = ({breakpoint}) => {
   return (
     <Typography>{location.path}:{location.line}</Typography>
   );
+}
+
+/** Whether a breakpoint is successful or failed. */
+export function breakpointIsSuccessful(breakpoint) {
+  const {status} = breakpoint;
+  return !status || !status.isError;
 }

--- a/app/src/client/markers/BreakpointMarker.tsx
+++ b/app/src/client/markers/BreakpointMarker.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import styled, { keyframes } from "styled-components";
 
+import Popover from '@material-ui/core/Popover';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+
 import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
 
 interface NewBreakpointMarkerProps {
@@ -37,7 +40,28 @@ interface CompletedBreakpointMarkerProps {
 export const CompletedBreakpointMarker = ({
   breakpoint,
 }: CompletedBreakpointMarkerProps) => {
-  return <CompletedBreakpointMarkerWrapper />;
+  return (
+    <PopupState variant="popover" popupId="completed-bp-popover">
+      {(popupState) => (
+        <>
+          <CompletedBreakpointMarkerWrapper {...bindTrigger(popupState)}/>
+          <Popover
+            {...bindPopover(popupState)}
+            anchorOrigin={{
+              vertical: "top",
+              horizontal: "left"
+            }}
+            transformOrigin={{
+              vertical: "top",
+              horizontal: "left"
+            }}
+          >
+            Hey
+          </Popover>
+        </>
+      )}
+    </PopupState>
+  )
 };
 
 /** UI that is shared by all types of breakpoint markers.

--- a/app/src/client/markers/BreakpointMarker.tsx
+++ b/app/src/client/markers/BreakpointMarker.tsx
@@ -5,7 +5,7 @@ import PopupState, {bindPopper, bindToggle } from 'material-ui-popup-state';
 
 import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
 import { Box, Popper, Paper, Backdrop } from "@material-ui/core";
-import { SuccessfulCompletedBreakpointData } from "../chathead/BreakpointView";
+import { SuccessfulCompletedBreakpointData, breakpointIsSuccessful, FailedCompletedBreakpointData } from "../chathead/BreakpointView";
 
 interface NewBreakpointMarkerProps {
   /** Callback for when new-breakpoint marker is clicked.
@@ -60,7 +60,13 @@ export const CompletedBreakpointMarker = ({
           >
             <Paper>
               <Box padding={3}>
-                <SuccessfulCompletedBreakpointData breakpoint={breakpoint}/>
+                {
+                  breakpointIsSuccessful(breakpoint) ? (
+                    <SuccessfulCompletedBreakpointData breakpoint={breakpoint}/>   
+                  ): (
+                    <FailedCompletedBreakpointData breakpoint={breakpoint}/>
+                  )
+                }
               </Box>
             </Paper>
           </Popper>

--- a/app/src/client/markers/BreakpointMarker.tsx
+++ b/app/src/client/markers/BreakpointMarker.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import styled, { keyframes } from "styled-components";
 
-import Popover from '@material-ui/core/Popover';
-import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+import PopupState, {bindPopper, bindToggle } from 'material-ui-popup-state';
 
 import { BreakpointMeta, Breakpoint } from "../../common/types/debugger";
+import { Box, Popper, Paper, Backdrop } from "@material-ui/core";
+import { SuccessfulCompletedBreakpointData } from "../chathead/BreakpointView";
 
 interface NewBreakpointMarkerProps {
   /** Callback for when new-breakpoint marker is clicked.
@@ -44,20 +45,25 @@ export const CompletedBreakpointMarker = ({
     <PopupState variant="popover" popupId="completed-bp-popover">
       {(popupState) => (
         <>
-          <CompletedBreakpointMarkerWrapper {...bindTrigger(popupState)}/>
-          <Popover
-            {...bindPopover(popupState)}
-            anchorOrigin={{
-              vertical: "top",
-              horizontal: "left"
-            }}
-            transformOrigin={{
-              vertical: "top",
-              horizontal: "left"
+          <CompletedBreakpointMarkerWrapper {...bindToggle(popupState)}/>
+          <Popper
+            {...bindPopper(popupState)}
+            placement="right-start"
+            disablePortal={false}
+            modifiers={{
+              flip: {enabled: false},
+              preventOverflow: {
+                enabled: true,
+                boundariesElement: 'viewport',
+              }
             }}
           >
-            Hey
-          </Popover>
+            <Paper>
+              <Box padding={3}>
+                <SuccessfulCompletedBreakpointData breakpoint={breakpoint}/>
+              </Box>
+            </Paper>
+          </Popper>
         </>
       )}
     </PopupState>


### PR DESCRIPTION
**Background**
Currently stacktrace data is only available in the chathead.

**Work done**
Refactored breakpoint view to allow integration of stacktrace data into the breakpoint marker, in a popover.
![image](https://user-images.githubusercontent.com/17712692/89067831-0dbacb00-d33e-11ea-8c2a-39b73937e8d8.png)

**Next Steps**
Suggest that the marker is clickable a bit better, whether through badge, hover effect, pulse, etc.