### PR TITLE
Remove over-eager load debuggee error

### DIFF
--- a/app/src/client/chathead/SelectDebuggee.tsx
+++ b/app/src/client/chathead/SelectDebuggee.tsx
@@ -77,11 +77,11 @@ export class SelectDebuggeeContainer extends React.Component<
           <Card>
             <CardContent>
               {
-                !this.state.error && this.state.debuggees.length === 0 && (
+                (!this.state.error && !this.state.debuggeesLoading && this.state.debuggees.length === 0) ? (
                   <Alert severity="warning">
                     No debuggees are active. This means your project hasn't run in a while, try using it to wake it up.
                   </Alert>
-                )
+                ) : null
               }
 
               {


### PR DESCRIPTION
**Background**
Currently, when the select-debuggee page loads, it will immediately show a 'no debuggee active' message, since the 0 debuggees it has in state is equivalent to no debuggees available.

**Work Done**
Further constrain that message to only show when no loading is taking place.